### PR TITLE
Implement Physics Engine up to 0.5.0

### DIFF
--- a/src/physics/collision_resolution.rs
+++ b/src/physics/collision_resolution.rs
@@ -1,0 +1,63 @@
+use crate::geometry::vector::Vector3d;
+use crate::physics::rigid_body::RigidBody;
+
+pub fn resolve_collision(
+    body1: &mut RigidBody,
+    body2: &mut RigidBody,
+    normal: Vector3d,
+    restitution: f32,
+    friction: f32,
+) {
+    if body1.inverse_mass + body2.inverse_mass == 0.0 {
+        return; // Both are static bodies
+    }
+
+    let relative_velocity = body2.velocity.subtract(&body1.velocity);
+
+    // Calculate velocity along the normal
+    let velocity_along_normal = relative_velocity.dot(&normal);
+
+    // Do not resolve if velocities are separating
+    if velocity_along_normal > 0.0 {
+        return;
+    }
+
+    // Calculate restitution
+    let e = restitution.min(body1.restitution.min(body2.restitution));
+
+    // Calculate impulse scalar
+    let mut j = -(1.0 + e) * velocity_along_normal;
+    j /= body1.inverse_mass + body2.inverse_mass;
+
+    // Apply impulse
+    let impulse = normal.scale(j);
+
+    body1.velocity = body1.velocity.subtract(&impulse.scale(body1.inverse_mass));
+    body2.velocity = body2.velocity.add(&impulse.scale(body2.inverse_mass));
+
+    // Friction
+    let relative_velocity_post_impulse = body2.velocity.subtract(&body1.velocity);
+
+    let tangent = relative_velocity_post_impulse.subtract(&normal.scale(relative_velocity_post_impulse.dot(&normal)));
+    if tangent.magnitude() > 0.0 {
+        let tangent = tangent.normalize();
+
+        // Calculate tangent velocity
+        let jt = -relative_velocity_post_impulse.dot(&tangent);
+        let mut jt = jt / (body1.inverse_mass + body2.inverse_mass);
+
+        // Calculate friction
+        let mu = friction.min(body1.friction.min(body2.friction));
+
+        // Clamp friction
+        let friction_impulse = if jt.abs() < j * mu {
+            tangent.scale(jt)
+        } else {
+            tangent.scale(-j * mu)
+        };
+
+        // Apply friction impulse
+        body1.velocity = body1.velocity.subtract(&friction_impulse.scale(body1.inverse_mass));
+        body2.velocity = body2.velocity.add(&friction_impulse.scale(body2.inverse_mass));
+    }
+}

--- a/src/physics/constraint.rs
+++ b/src/physics/constraint.rs
@@ -1,0 +1,122 @@
+use crate::physics::rigid_body::RigidBody;
+
+pub trait Constraint {
+    // Solves positional errors. Called multiple times per frame.
+    fn solve(&self, bodies: &mut [RigidBody], dt: f32);
+
+    // Calculates and applies forces. Called once per frame, before integration.
+    fn apply_forces(&self, _bodies: &mut [RigidBody], _dt: f32) {}
+}
+
+pub struct DistanceJoint {
+    pub body_a_index: usize,
+    pub body_b_index: usize,
+    pub target_distance: f32,
+    pub stiffness: f32, // Allows for both rigid and soft distance joints
+}
+
+impl DistanceJoint {
+    pub fn new(body_a_index: usize, body_b_index: usize, target_distance: f32, stiffness: f32) -> Self {
+        Self {
+            body_a_index,
+            body_b_index,
+            target_distance,
+            stiffness,
+        }
+    }
+}
+
+impl Constraint for DistanceJoint {
+    fn solve(&self, bodies: &mut [RigidBody], _dt: f32) {
+        if self.body_a_index == self.body_b_index {
+            return;
+        }
+
+        let body_a_pos = bodies[self.body_a_index].position;
+        let body_b_pos = bodies[self.body_b_index].position;
+        let mass_a_inv = bodies[self.body_a_index].inverse_mass;
+        let mass_b_inv = bodies[self.body_b_index].inverse_mass;
+
+        if mass_a_inv + mass_b_inv == 0.0 {
+            return;
+        }
+
+        let direction = body_b_pos.subtract(&body_a_pos);
+        let distance = direction.magnitude();
+
+        if distance == 0.0 {
+            return;
+        }
+
+        let normal = direction.normalize();
+        let error = distance - self.target_distance;
+
+        let correction_magnitude = error * self.stiffness / (mass_a_inv + mass_b_inv);
+        let correction = normal.scale(correction_magnitude);
+
+        bodies[self.body_a_index].position = bodies[self.body_a_index].position.add(&correction.scale(mass_a_inv));
+        bodies[self.body_b_index].position = bodies[self.body_b_index].position.subtract(&correction.scale(mass_b_inv));
+    }
+}
+
+pub struct SpringJoint {
+    pub body_a_index: usize,
+    pub body_b_index: usize,
+    pub rest_length: f32,
+    pub spring_constant: f32,
+    pub damping: f32,
+}
+
+impl SpringJoint {
+    pub fn new(body_a_index: usize, body_b_index: usize, rest_length: f32, spring_constant: f32, damping: f32) -> Self {
+        Self {
+            body_a_index,
+            body_b_index,
+            rest_length,
+            spring_constant,
+            damping,
+        }
+    }
+}
+
+impl Constraint for SpringJoint {
+    fn solve(&self, _bodies: &mut [RigidBody], _dt: f32) {
+        // Spring joints apply forces, not direct positional corrections
+    }
+
+    fn apply_forces(&self, bodies: &mut [RigidBody], _dt: f32) {
+        if self.body_a_index == self.body_b_index {
+            return;
+        }
+
+        let body_a_pos = bodies[self.body_a_index].position;
+        let body_b_pos = bodies[self.body_b_index].position;
+        let body_a_vel = bodies[self.body_a_index].velocity;
+        let body_b_vel = bodies[self.body_b_index].velocity;
+
+        let direction = body_b_pos.subtract(&body_a_pos);
+        let distance = direction.magnitude();
+
+        if distance == 0.0 {
+            return;
+        }
+
+        let normal = direction.normalize();
+
+        // Spring force: F = -k * x
+        let displacement = distance - self.rest_length;
+        let spring_force = self.spring_constant * displacement;
+
+        // Damping force: F_d = -c * v_rel
+        let rel_vel = body_b_vel.subtract(&body_a_vel);
+        let vel_along_normal = rel_vel.dot(&normal);
+        let damping_force = self.damping * vel_along_normal;
+
+        let total_force_mag = spring_force + damping_force;
+        let total_force = normal.scale(total_force_mag);
+
+        // Apply forces
+        bodies[self.body_a_index].apply_force(&total_force);
+        bodies[self.body_b_index].apply_force(&total_force.scale(-1.0));
+    }
+}

--- a/src/physics/integrator.rs
+++ b/src/physics/integrator.rs
@@ -1,0 +1,58 @@
+use crate::geometry::vector::Vector3d;
+use crate::physics::rigid_body::RigidBody;
+
+pub trait Integrator {
+    fn integrate(&self, body: &mut RigidBody, dt: f32, gravity: &Vector3d);
+}
+
+pub struct Euler;
+
+impl Integrator for Euler {
+    fn integrate(&self, body: &mut RigidBody, dt: f32, gravity: &Vector3d) {
+        if body.inverse_mass <= 0.0 {
+            return;
+        }
+
+        let gravity_force = gravity.scale(body.mass * body.gravity_scale);
+        let total_force = body.force_accumulator.add(&gravity_force);
+
+        // a = F / m
+        body.acceleration = total_force.scale(body.inverse_mass);
+
+        // p = p + v * dt
+        body.position = body.position.add(&body.velocity.scale(dt));
+
+        // v = v + a * dt
+        body.velocity = body.velocity.add(&body.acceleration.scale(dt));
+
+        body.velocity = body.velocity.scale(body.damping.powf(dt));
+
+        body.clear_forces();
+    }
+}
+
+pub struct SemiImplicitEuler;
+
+impl Integrator for SemiImplicitEuler {
+    fn integrate(&self, body: &mut RigidBody, dt: f32, gravity: &Vector3d) {
+        if body.inverse_mass <= 0.0 {
+            return;
+        }
+
+        let gravity_force = gravity.scale(body.mass * body.gravity_scale);
+        let total_force = body.force_accumulator.add(&gravity_force);
+
+        // a = F / m
+        body.acceleration = total_force.scale(body.inverse_mass);
+
+        // v = v + a * dt
+        body.velocity = body.velocity.add(&body.acceleration.scale(dt));
+
+        body.velocity = body.velocity.scale(body.damping.powf(dt));
+
+        // p = p + v * dt
+        body.position = body.position.add(&body.velocity.scale(dt));
+
+        body.clear_forces();
+    }
+}

--- a/src/physics/mod.rs
+++ b/src/physics/mod.rs
@@ -1,3 +1,9 @@
 pub mod circle_collision;
 pub mod aabb_collision;
 pub mod sat_collision;
+pub mod rigid_body;
+pub mod integrator;
+pub mod collision_resolution;
+pub mod world;
+pub mod constraint;
+pub mod soft_body;

--- a/src/physics/rigid_body.rs
+++ b/src/physics/rigid_body.rs
@@ -1,0 +1,74 @@
+use crate::geometry::vector::Vector3d;
+
+#[derive(Debug, Clone)]
+pub enum Shape {
+    Circle(f32), // radius
+    AABB(Vector3d), // half_extents
+}
+
+#[derive(Debug, Clone)]
+pub struct RigidBody {
+    pub position: Vector3d,
+    pub velocity: Vector3d,
+    pub acceleration: Vector3d,
+    pub mass: f32,
+    pub inverse_mass: f32,
+    pub force_accumulator: Vector3d,
+    pub gravity_scale: f32,
+    pub damping: f32, // Air resistance
+    pub friction: f32,
+    pub restitution: f32,
+    pub shape: Shape,
+}
+
+impl RigidBody {
+    pub fn new(position: Vector3d, mass: f32, shape: Shape) -> Self {
+        let inverse_mass = if mass > 0.0 { 1.0 / mass } else { 0.0 };
+        Self {
+            position,
+            velocity: Vector3d::new(0.0, 0.0, 0.0),
+            acceleration: Vector3d::new(0.0, 0.0, 0.0),
+            mass,
+            inverse_mass,
+            force_accumulator: Vector3d::new(0.0, 0.0, 0.0),
+            gravity_scale: 1.0,
+            damping: 0.98,
+            friction: 0.5,
+            restitution: 0.5,
+            shape,
+        }
+    }
+
+    pub fn apply_force(&mut self, force: &Vector3d) {
+        self.force_accumulator = self.force_accumulator.add(force);
+    }
+
+    pub fn clear_forces(&mut self) {
+        self.force_accumulator = Vector3d::new(0.0, 0.0, 0.0);
+    }
+
+    pub fn update(&mut self, dt: f32, gravity: &Vector3d) {
+        if self.inverse_mass <= 0.0 {
+            return; // Static body
+        }
+
+        // Add gravity to the force accumulator
+        let gravity_force = gravity.scale(self.mass * self.gravity_scale);
+        let total_force = self.force_accumulator.add(&gravity_force);
+
+        // a = F / m
+        self.acceleration = total_force.scale(self.inverse_mass);
+
+        // v = v + a * dt
+        self.velocity = self.velocity.add(&self.acceleration.scale(dt));
+
+        // Apply damping (air resistance)
+        self.velocity = self.velocity.scale(self.damping.powf(dt));
+
+        // p = p + v * dt
+        self.position = self.position.add(&self.velocity.scale(dt));
+
+        // Clear forces after applying them
+        self.clear_forces();
+    }
+}

--- a/src/physics/soft_body.rs
+++ b/src/physics/soft_body.rs
@@ -1,0 +1,40 @@
+use crate::geometry::vector::Vector3d;
+use crate::physics::rigid_body::{RigidBody, Shape};
+use crate::physics::constraint::{Constraint, SpringJoint};
+
+pub struct SoftBody {
+    pub nodes: Vec<RigidBody>,
+    pub springs: Vec<SpringJoint>,
+}
+
+impl SoftBody {
+    pub fn new() -> Self {
+        Self {
+            nodes: Vec::new(),
+            springs: Vec::new(),
+        }
+    }
+
+    pub fn add_node(&mut self, position: Vector3d, mass: f32) -> usize {
+        let index = self.nodes.len();
+        // Soft bodies often use small point masses (small circles)
+        self.nodes.push(RigidBody::new(position, mass, Shape::Circle(0.1)));
+        index
+    }
+
+    pub fn add_spring(&mut self, index_a: usize, index_b: usize, rest_length: f32, stiffness: f32, damping: f32) {
+        self.springs.push(SpringJoint::new(index_a, index_b, rest_length, stiffness, damping));
+    }
+
+    pub fn apply_forces(&mut self, dt: f32) {
+        for spring in &self.springs {
+            spring.apply_forces(&mut self.nodes, dt);
+        }
+    }
+
+    pub fn solve_constraints(&mut self, dt: f32) {
+        for spring in &self.springs {
+            spring.solve(&mut self.nodes, dt);
+        }
+    }
+}

--- a/src/physics/world.rs
+++ b/src/physics/world.rs
@@ -1,0 +1,194 @@
+use crate::geometry::vector::Vector3d;
+use crate::physics::rigid_body::{RigidBody, Shape};
+use crate::physics::integrator::Integrator;
+use crate::physics::aabb_collision::AABB;
+use crate::physics::collision_resolution::resolve_collision;
+use crate::physics::constraint::Constraint;
+use crate::physics::soft_body::SoftBody;
+
+pub struct PhysicsWorld {
+    pub bodies: Vec<RigidBody>,
+    pub soft_bodies: Vec<SoftBody>,
+    pub constraints: Vec<Box<dyn Constraint>>,
+    pub integrator: Box<dyn Integrator>,
+    pub fixed_time_step: f32,
+    pub accumulator: f32,
+    pub gravity: Vector3d,
+}
+
+impl PhysicsWorld {
+    pub fn new(integrator: Box<dyn Integrator>, fixed_time_step: f32) -> Self {
+        Self {
+            bodies: Vec::new(),
+            soft_bodies: Vec::new(),
+            constraints: Vec::new(),
+            integrator,
+            fixed_time_step,
+            accumulator: 0.0,
+            gravity: Vector3d::new(0.0, -9.81, 0.0), // Default gravity
+        }
+    }
+
+    pub fn add_constraint(&mut self, constraint: Box<dyn Constraint>) {
+        self.constraints.push(constraint);
+    }
+
+    pub fn add_body(&mut self, body: RigidBody) {
+        self.bodies.push(body);
+    }
+
+    pub fn add_soft_body(&mut self, soft_body: SoftBody) {
+        self.soft_bodies.push(soft_body);
+    }
+
+    pub fn step(&mut self, dt: f32) {
+        self.accumulator += dt;
+
+        while self.accumulator >= self.fixed_time_step {
+            // 1. Apply Constraint Forces (Once per step)
+            for constraint in &self.constraints {
+                constraint.apply_forces(&mut self.bodies, self.fixed_time_step);
+            }
+
+            // Also for SoftBodies
+            for soft_body in &mut self.soft_bodies {
+                soft_body.apply_forces(self.fixed_time_step);
+            }
+
+            // 2. Integration (Update velocities and positions)
+            for body in &mut self.bodies {
+                self.integrator.integrate(body, self.fixed_time_step, &self.gravity);
+            }
+
+            for soft_body in &mut self.soft_bodies {
+                for node in &mut soft_body.nodes {
+                    self.integrator.integrate(node, self.fixed_time_step, &self.gravity);
+                }
+            }
+
+            // 3. Collision Detection and Resolution
+            let potential_collisions = self.broad_phase();
+            self.narrow_phase(&potential_collisions);
+
+            // 4. Positional Constraint Solving (Iterative)
+            for _ in 0..10 {
+                for constraint in &self.constraints {
+                    constraint.solve(&mut self.bodies, self.fixed_time_step);
+                }
+
+                for soft_body in &mut self.soft_bodies {
+                    soft_body.solve_constraints(self.fixed_time_step);
+                }
+            }
+
+            self.accumulator -= self.fixed_time_step;
+        }
+    }
+
+    pub fn broad_phase(&mut self) -> Vec<(usize, usize)> {
+        let mut potential_collisions = Vec::new();
+
+        // Calculate AABBs for all bodies
+        let aabbs: Vec<AABB> = self.bodies.iter().map(|body| {
+            match body.shape {
+                Shape::Circle(radius) => {
+                    AABB::from_center_and_size(
+                        body.position,
+                        Vector3d::new(radius * 2.0, radius * 2.0, radius * 2.0),
+                    )
+                },
+                Shape::AABB(half_extents) => {
+                    AABB::from_center_and_size(
+                        body.position,
+                        half_extents.scale(2.0),
+                    )
+                }
+            }
+        }).collect();
+
+        // O(N^2) naive check - could be optimized with Sweep and Prune or Spatial Partitioning
+        for i in 0..aabbs.len() {
+            for j in (i + 1)..aabbs.len() {
+                if aabbs[i].collides_with(&aabbs[j]) {
+                    potential_collisions.push((i, j));
+                }
+            }
+        }
+
+        potential_collisions
+    }
+
+    pub fn narrow_phase(&mut self, potential_collisions: &[(usize, usize)]) {
+        for &(i, j) in potential_collisions {
+            let body1 = &self.bodies[i];
+            let body2 = &self.bodies[j];
+
+            // Temporary way to extract data needed for narrow phase, to get around mutability borrow checks
+            let shape1 = body1.shape.clone();
+            let shape2 = body2.shape.clone();
+            let pos1 = body1.position;
+            let pos2 = body2.position;
+
+            let collision_data = match (&shape1, &shape2) {
+                (Shape::Circle(r1), Shape::Circle(r2)) => {
+                    let distance_squared = pos1.distance_to(&pos2).powi(2);
+                    let radius_sum = r1 + r2;
+                    if distance_squared <= radius_sum.powi(2) {
+                        let distance = distance_squared.sqrt();
+                        let normal = if distance == 0.0 {
+                            Vector3d::new(1.0, 0.0, 0.0) // Arbitrary normal if same position
+                        } else {
+                            pos2.subtract(&pos1).normalize()
+                        };
+                        Some(normal)
+                    } else {
+                        None
+                    }
+                },
+                (Shape::AABB(he1), Shape::AABB(he2)) => {
+                    // SAT or simpler AABB vs AABB overlap logic returning penetration vector
+                    let aabb1 = AABB::from_center_and_size(pos1, he1.scale(2.0));
+                    let aabb2 = AABB::from_center_and_size(pos2, he2.scale(2.0));
+                    if aabb1.collides_with(&aabb2) {
+                        // Calculate a simplistic resolution normal for demonstration
+                        Some(pos2.subtract(&pos1).normalize())
+                    } else {
+                        None
+                    }
+                },
+                (Shape::Circle(r), Shape::AABB(he)) => {
+                    let aabb = AABB::from_center_and_size(pos2, he.scale(2.0));
+                    if aabb.intersects_circle(&pos1, *r) {
+                        Some(pos1.subtract(&pos2).normalize())
+                    } else {
+                        None
+                    }
+                },
+                (Shape::AABB(he), Shape::Circle(r)) => {
+                    let aabb = AABB::from_center_and_size(pos1, he.scale(2.0));
+                    if aabb.intersects_circle(&pos2, *r) {
+                        Some(pos2.subtract(&pos1).normalize())
+                    } else {
+                        None
+                    }
+                }
+            };
+
+            if let Some(normal) = collision_data {
+                // To resolve collision we need to borrow mutably
+                // We split the borrow to get two mut references
+                if i < j {
+                    let (left, right) = self.bodies.split_at_mut(j);
+                    let b1 = &mut left[i];
+                    let b2 = &mut right[0];
+                    resolve_collision(b1, b2, normal, 0.5, 0.5); // Default restitution and friction for now
+                } else {
+                    let (left, right) = self.bodies.split_at_mut(i);
+                    let b2 = &mut left[j];
+                    let b1 = &mut right[0];
+                    resolve_collision(b1, b2, normal, 0.5, 0.5);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements all physics engine roadmap features up to version 0.5.0, including rigid bodies, numerical integrators, collision resolution, broad and narrow-phase collision detection, soft bodies, and constraint solvers.

---
*PR created automatically by Jules for task [10554676126981394649](https://jules.google.com/task/10554676126981394649) started by @DanielMarcos1*