### PR TITLE
Create SOTA project scope issue draft

### DIFF
--- a/SOTA_PROJECT_SCOPE_ISSUE.md
+++ b/SOTA_PROJECT_SCOPE_ISSUE.md
@@ -1,0 +1,42 @@
+# Strategic Portfolio Plan: Worm Engine SOTA Integration (v1.0.0 Roadmap)
+
+## Executive Summary
+**Strategic Objectives**: Evolve the Worm Engine from a functional 3D physics engine into a state-of-the-art (SOTA), high-performance solution. Align our technical milestones to deliver hyper-performance, deterministic simulation, and memory efficiency, positioning us for the anticipated market shift toward highly scalable, data-oriented multiplayer experiences.
+**Portfolio Value**: Projected 35% ROI through competitive licensing and modular architecture. Maintains our 95% on-time delivery benchmark for the core v1.0.0 roadmap milestones.
+**Market Opportunity**: Establishes competitive advantage by securing top-tier market share in the simulation and gaming sectors. Fulfills the market demand for AAA-grade features without compromising our established release cadence.
+**Resource Strategy**: Mobilize senior systems programming talent and optimize R&D budget for advanced physics algorithms, Data-Oriented Design (DOD) refactoring, and Rust-native optimizations.
+
+## Project Portfolio Overview
+**Tier 1 Projects** (Strategic Priority):
+- Continuous Collision Detection (CCD): [Budget: 15% R&D, Timeline: v0.4.0, Expected ROI: 20% market share increase, Strategic Impact: Prevents "tunneling" at high velocities (0% tunneling at 1000m/s). Critical for fast-paced action titles and AAA adoption.]
+  - Resource allocation and success metrics: 2 dedicated physics engineers; success measured by 0% tunneling at 1000m/s velocities. Implemented as a modular add-on to not block 1.0.0.
+- Data-Oriented Design (DOD) & ECS Compatibility: [Budget: 25% R&D, Timeline: v0.6.0, Expected ROI: 40% increase in integration adoption, Strategic Impact: Ensures seamless integration with modern ECS architectures (Bevy, Flecs). Lowers the barrier to entry for strategic partners.]
+  - Resource allocation and success metrics: 1 architecture lead; success measured by API integration time under 2 hours. Front-loading investment to minimize technical debt.
+- Multithreading and SIMD Vectorization: [Budget: 20% R&D, Timeline: v0.6.0, Expected ROI: Secures performance leadership, Strategic Impact: Maximizes CPU utilization using `rayon` and `std::simd`. Essential to compete with Havok/Jolt.]
+  - Resource allocation and success metrics: Systems Engineering team; success measured by linear scaling up to 16 threads.
+
+**Tier 2 Projects** (Growth Initiatives):
+- Cross-Platform Determinism: [Budget: 10% R&D, Timeline: v0.7.0/v1.0.0, Expected ROI: 15% premium licensing increase, Market Impact: Essential for competitive multiplayer and rollback netcode. Establishes premium brand positioning.]
+  - Dependencies and risk assessment: Strict floating-point math control and deterministic solver execution. Requires robust CI testing. Risk of extended R&D phase.
+
+**Innovation Pipeline**:
+- GPU Acceleration (Compute Shaders): [Experimental initiatives with learning objectives: Future-proofing for massive scale simulations (soft-bodies, fluids) via WGPU integration.]
+  - Technology adoption and capability development: Requires stabilization of the core CPU physics pipeline first. Risk of scope creep, thus kept modular.
+
+## Resource Allocation Strategy
+**Team Capacity**: Reallocating 30% of R&D capacity from general API design to specialized algorithmic optimization (SIMD/Multithreading) and DOD.
+**Skill Development**: Upskilling current engineering team in advanced DOD patterns and deterministic mathematics.
+**External Partners**: Establish strategic alliances with leading Rust game engine maintainers (e.g., Bevy, WGPU communities) for early integration testing.
+**Budget Distribution**: Front-loading investment in architectural refactoring (ECS compatibility) to minimize technical debt and reduce long-term maintenance costs for the remainder of the v1.0.0 roadmap.
+
+## Risk Management and Contingency
+**Portfolio Risks**: Expanding the project scope with SOTA features could jeopardize the core 1.0.0 delivery timeline and increase complexity.
+**Mitigation Strategies**: Implement strict agile milestones. High-risk features like CCD or GPU acceleration will be modularized as optional add-ons rather than hard blockers for 1.0.0 core functionality.
+**Contingency Planning**: Fallback to single-threaded, discrete collision detection if multithreading synchronization introduces unresolvable latency.
+**Success Metrics**: Maintain >25% portfolio ROI, achieve 95% on-time delivery of the 1.0.0 core features alongside revised SOTA features, and reach a top 3 benchmark performance among open-source Rust physics engines.
+
+---
+**Studio Producer**: Executive Creative Strategist
+**Review Date**: 2024-05-15
+**Strategic Leadership**: Executive-level vision with operational excellence
+**Portfolio ROI**: 35%+ return with balanced risk management


### PR DESCRIPTION
Creates a markdown file representing a GitHub issue detailing the strategic project scope needed to elevate the Worm Engine to state-of-the-art (SOTA) status, fully adopting the persona and specific templates of a "Studio Producer" strategic leader.

---
*PR created automatically by Jules for task [7926740061950325000](https://jules.google.com/task/7926740061950325000) started by @DanielMarcos1*