### PR TITLE
Fix compilation errors and warnings

### DIFF
--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,12 @@
+1.  **Fix compilation errors in `src/physics/world.rs`**:
+    *   The `World` struct currently has un-imported/undefined types: `Position`, `Velocity`, `Acceleration`, `Force`, `Mass`, and `Shape`. Based on the codebase, these shouldn't be new structs but rather types from `components.rs` or `vector.rs`.
+    *   Actually, `World` currently has both `bodies: RigidBodyComponents` *and* `positions: Vec<Position>`, etc. `RigidBodyComponents` is already a SoA layout. I should remove the duplicated, undefined fields (`positions`, `velocities`, `accelerations`, `forces`, `masses`, `shapes`, `active_entities`) from `World` to fix the `cannot find type` errors, or replace them with proper types (e.g., `Vector3d`, `f32`, `Polygon`) if we are migrating entirely to flat arrays in `World`. Let's just remove them as `RigidBodyComponents` contains exactly those properties.
+2.  **Fix `f32x4` import error in `src/geometry/vector.rs`**:
+    *   Add `use wide::f32x4;` to `src/geometry/vector.rs`.
+3.  **Fix warnings**:
+    *   Remove unnecessary `mut` in `src/physics/rigid_body.rs` and `src/physics/world.rs`.
+    *   Prefix `submission_index` with an underscore in `src/physics/gpu.rs`.
+    *   Remove unused import `physics::rigid_body` in `src/physics/world.rs`.
+4.  **Complete pre-commit steps**:
+    *   Run tests and verification steps.
+5.  **Submit the change**.

--- a/src/geometry/vector.rs
+++ b/src/geometry/vector.rs
@@ -1,5 +1,6 @@
 use bytemuck::{Pod, Zeroable};
 use crate::physics::math::DeterministicMath;
+use wide::f32x4;
 
 #[repr(C)]
 #[derive(Debug, Clone, Copy, Pod, Zeroable)]

--- a/src/physics/gpu.rs
+++ b/src/physics/gpu.rs
@@ -118,7 +118,7 @@ impl GpuContext {
         );
 
         // Submit the commands to the queue
-        let submission_index = self.queue.submit(Some(encoder.finish()));
+        let _submission_index = self.queue.submit(Some(encoder.finish()));
 
         // Map the staging buffer so we can read it on CPU
         let buffer_slice = staging_buffer.slice(..);

--- a/src/physics/rigid_body.rs
+++ b/src/physics/rigid_body.rs
@@ -13,7 +13,7 @@ pub fn update(components: &mut RigidBodyComponents, index: usize, dt: f32) {
     let mass = components.masses[index];
     let force = components.forces[index];
 
-    let mut accel = force.scale(1.0 / mass);
+    let accel = force.scale(1.0 / mass);
     components.accelerations[index] = accel;
 
     let mut vel = components.velocities[index];

--- a/src/physics/world.rs
+++ b/src/physics/world.rs
@@ -1,4 +1,4 @@
-use crate::{geometry::polygon::Polygon, physics::components::RigidBodyComponents, physics::rigid_body};
+use crate::{geometry::polygon::Polygon, physics::components::RigidBodyComponents};
 use rayon::prelude::*;
 use wide::f32x4;
 use crate::geometry::vector::Vector3d;
@@ -8,15 +8,6 @@ pub struct World {
     pub bodies: RigidBodyComponents,
     pub time_step: f32,
     pub next_entity: usize,
-
-    // SoA (Struct of Arrays) layout for DOD
-    pub positions: Vec<Position>,
-    pub velocities: Vec<Velocity>,
-    pub accelerations: Vec<Acceleration>,
-    pub forces: Vec<Force>,
-    pub masses: Vec<Mass>,
-    pub shapes: Vec<Shape>,
-    pub active_entities: Vec<bool>, // true if entity is active
 }
 
 impl World {
@@ -25,13 +16,6 @@ impl World {
             bodies: RigidBodyComponents::new(),
             time_step,
             next_entity: 0,
-            positions: Vec::new(),
-            velocities: Vec::new(),
-            accelerations: Vec::new(),
-            forces: Vec::new(),
-            masses: Vec::new(),
-            shapes: Vec::new(),
-            active_entities: Vec::new(),
         }
     }
 
@@ -116,7 +100,7 @@ impl World {
             for i in start..end {
                 let mass = self.bodies.masses[i];
                 let gravity_force = crate::physics::constants::GRAVITY.scale(mass);
-                let mut force = self.bodies.forces[i].add(&gravity_force);
+                let force = self.bodies.forces[i].add(&gravity_force);
 
                 let accel = force.scale(1.0 / mass);
                 self.bodies.accelerations[i] = accel;

--- a/test_script.sh
+++ b/test_script.sh
@@ -1,0 +1,2 @@
+cargo check
+cargo test


### PR DESCRIPTION
This PR addresses compilation issues that were preventing the project from building successfully using `cargo check` and `cargo test`. It removes duplicate definitions of SoA arrays in `World` that were already handled by `RigidBodyComponents`, fixes missing SIMD imports, and resolves several warnings across the codebase.

---
*PR created automatically by Jules for task [4807092959921511987](https://jules.google.com/task/4807092959921511987) started by @DanielMarcos1*