### PR TITLE
Fix DOD SoA architecture and SIMD implementation

### DIFF
--- a/src/geometry/vector.rs
+++ b/src/geometry/vector.rs
@@ -23,36 +23,30 @@ impl Vector3d {
         }
     }
 
-    // Internal helper to get SIMD representation (padding with 0.0)
-    #[inline(always)]
-    fn to_simd(&self) -> f32x4 {
-        f32x4::new([self.x, self.y, self.z, 0.0])
-    }
-
-    // Internal helper to create Vector3d from SIMD
-    #[inline(always)]
-    fn from_simd(simd: f32x4) -> Self {
-        let arr = simd.to_array();
+    // A vector of 3d must have basic arithmetic calculations to represent it's location on the environment
+    pub fn add(&self, other: &Vector3d) -> Vector3d {
         Self {
-            x: arr[0],
-            y: arr[1],
-            z: arr[2],
+            x: self.x + other.x,
+            y: self.y + other.y,
+            z: self.z + other.z,
         }
     }
 
-    // A vector of 3d must have basic arithmetic calculations to represent it's location on the environment
-    pub fn add(&self, other: &Vector3d) -> Vector3d {
-        Self::from_simd(self.to_simd() + other.to_simd())
-    }
-
     pub fn subtract(&self, other: &Vector3d) -> Vector3d {
-        Self::from_simd(self.to_simd() - other.to_simd())
+        Self {
+            x: self.x - other.x,
+            y: self.y - other.y,
+            z: self.z - other.z,
+        }
     }
 
     // Scalar multiplication has the purpose to control vector speed without changing its direction
     pub fn scale(&self, scalar: f32) -> Vector3d {
-        let scalar_simd = f32x4::splat(scalar);
-        Self::from_simd(self.to_simd() * scalar_simd)
+        Self {
+            x: self.x * scalar,
+            y: self.y * scalar,
+            z: self.z * scalar,
+        }
     }
 
     // This represents the length or size of the vector
@@ -72,9 +66,7 @@ impl Vector3d {
 
     // Look at where the vector is pointing at and it's relative direction compared to other vectors
     pub fn dot(&self, other: &Vector3d) -> f32 {
-        let mul = self.to_simd() * other.to_simd();
-        let arr = mul.to_array();
-        arr[0] + arr[1] + arr[2]
+        self.x * other.x + self.y * other.y + self.z * other.z
     }
 
     // This can be used to calculate many things like perpendicular directions,

--- a/src/physics/components.rs
+++ b/src/physics/components.rs
@@ -4,9 +4,15 @@ use crate::geometry::{vector::Vector3d, polygon::Polygon};
 pub struct RigidBodyComponents {
     pub shapes: Vec<Polygon>,
     pub masses: Vec<f32>,
-    pub velocities: Vec<Vector3d>,
-    pub accelerations: Vec<Vector3d>,
-    pub forces: Vec<Vector3d>,
+    pub velocities_x: Vec<f32>,
+    pub velocities_y: Vec<f32>,
+    pub velocities_z: Vec<f32>,
+    pub accelerations_x: Vec<f32>,
+    pub accelerations_y: Vec<f32>,
+    pub accelerations_z: Vec<f32>,
+    pub forces_x: Vec<f32>,
+    pub forces_y: Vec<f32>,
+    pub forces_z: Vec<f32>,
 }
 
 impl RigidBodyComponents {
@@ -18,9 +24,15 @@ impl RigidBodyComponents {
         assert!(mass > 0.0, "Mass must be greater than zero");
         self.shapes.push(shape);
         self.masses.push(mass);
-        self.velocities.push(Vector3d::zero());
-        self.accelerations.push(Vector3d::zero());
-        self.forces.push(Vector3d::zero());
+        self.velocities_x.push(0.0);
+        self.velocities_y.push(0.0);
+        self.velocities_z.push(0.0);
+        self.accelerations_x.push(0.0);
+        self.accelerations_y.push(0.0);
+        self.accelerations_z.push(0.0);
+        self.forces_x.push(0.0);
+        self.forces_y.push(0.0);
+        self.forces_z.push(0.0);
     }
 
     pub fn len(&self) -> usize {

--- a/src/physics/gpu.rs
+++ b/src/physics/gpu.rs
@@ -118,7 +118,7 @@ impl GpuContext {
         );
 
         // Submit the commands to the queue
-        let submission_index = self.queue.submit(Some(encoder.finish()));
+        let _submission_index = self.queue.submit(Some(encoder.finish()));
 
         // Map the staging buffer so we can read it on CPU
         let buffer_slice = staging_buffer.slice(..);

--- a/src/physics/rigid_body.rs
+++ b/src/physics/rigid_body.rs
@@ -1,28 +1,44 @@
 use crate::{geometry::vector::Vector3d, physics::{constants::GRAVITY, components::RigidBodyComponents}};
 
 pub fn apply_force(components: &mut RigidBodyComponents, index: usize, force: Vector3d) {
-    components.forces[index] = components.forces[index].add(&force);
+    components.forces_x[index] += force.x;
+    components.forces_y[index] += force.y;
+    components.forces_z[index] += force.z;
 }
 
 pub fn apply_gravity(components: &mut RigidBodyComponents, index: usize) {
     let force = GRAVITY.scale(components.masses[index]);
-    components.forces[index] = components.forces[index].add(&force);
+    components.forces_x[index] += force.x;
+    components.forces_y[index] += force.y;
+    components.forces_z[index] += force.z;
 }
 
 pub fn update(components: &mut RigidBodyComponents, index: usize, dt: f32) {
     let mass = components.masses[index];
-    let force = components.forces[index];
 
-    let mut accel = force.scale(1.0 / mass);
-    components.accelerations[index] = accel;
+    let a_x = components.forces_x[index] / mass;
+    let a_y = components.forces_y[index] / mass;
+    let a_z = components.forces_z[index] / mass;
 
-    let mut vel = components.velocities[index];
-    vel = vel.add(&accel.scale(dt));
-    components.velocities[index] = vel;
+    components.accelerations_x[index] = a_x;
+    components.accelerations_y[index] = a_y;
+    components.accelerations_z[index] = a_z;
+
+    components.velocities_x[index] += a_x * dt;
+    components.velocities_y[index] += a_y * dt;
+    components.velocities_z[index] += a_z * dt;
+
+    let vel = Vector3d::new(
+        components.velocities_x[index],
+        components.velocities_y[index],
+        components.velocities_z[index]
+    );
 
     for vertex in &mut components.shapes[index].vertices {
         *vertex = vertex.add(&vel.scale(dt));
     }
 
-    components.forces[index] = Vector3d::zero();
+    components.forces_x[index] = 0.0;
+    components.forces_y[index] = 0.0;
+    components.forces_z[index] = 0.0;
 }

--- a/src/physics/world.rs
+++ b/src/physics/world.rs
@@ -1,4 +1,4 @@
-use crate::{geometry::polygon::Polygon, physics::components::RigidBodyComponents, physics::rigid_body};
+use crate::{geometry::polygon::Polygon, physics::components::RigidBodyComponents};
 use rayon::prelude::*;
 use wide::f32x4;
 use crate::geometry::vector::Vector3d;
@@ -8,14 +8,6 @@ pub struct World {
     pub bodies: RigidBodyComponents,
     pub time_step: f32,
     pub next_entity: usize,
-
-    // SoA (Struct of Arrays) layout for DOD
-    pub positions: Vec<Position>,
-    pub velocities: Vec<Velocity>,
-    pub accelerations: Vec<Acceleration>,
-    pub forces: Vec<Force>,
-    pub masses: Vec<Mass>,
-    pub shapes: Vec<Shape>,
     pub active_entities: Vec<bool>, // true if entity is active
 }
 
@@ -25,12 +17,6 @@ impl World {
             bodies: RigidBodyComponents::new(),
             time_step,
             next_entity: 0,
-            positions: Vec::new(),
-            velocities: Vec::new(),
-            accelerations: Vec::new(),
-            forces: Vec::new(),
-            masses: Vec::new(),
-            shapes: Vec::new(),
             active_entities: Vec::new(),
         }
     }
@@ -54,56 +40,72 @@ impl World {
         // Process in chunks of 4 for SIMD vectorization
         self.bodies.shapes[..exact_len].par_chunks_mut(chunk_size)
             .zip(self.bodies.masses[..exact_len].par_chunks_mut(chunk_size))
-            .zip(self.bodies.velocities[..exact_len].par_chunks_mut(chunk_size))
-            .zip(self.bodies.accelerations[..exact_len].par_chunks_mut(chunk_size))
-            .zip(self.bodies.forces[..exact_len].par_chunks_mut(chunk_size))
-            .for_each(|((((shapes, masses), velocities), accelerations), forces)| {
+            .zip(self.bodies.velocities_x[..exact_len].par_chunks_mut(chunk_size))
+            .zip(self.bodies.velocities_y[..exact_len].par_chunks_mut(chunk_size))
+            .zip(self.bodies.velocities_z[..exact_len].par_chunks_mut(chunk_size))
+            .zip(self.bodies.accelerations_x[..exact_len].par_chunks_mut(chunk_size))
+            .zip(self.bodies.accelerations_y[..exact_len].par_chunks_mut(chunk_size))
+            .zip(self.bodies.accelerations_z[..exact_len].par_chunks_mut(chunk_size))
+            .zip(self.bodies.forces_x[..exact_len].par_chunks_mut(chunk_size))
+            .zip(self.bodies.forces_y[..exact_len].par_chunks_mut(chunk_size))
+            .zip(self.bodies.forces_z[..exact_len].par_chunks_mut(chunk_size))
+            .for_each(|((((((((((shapes, masses), v_x), v_y), v_z), a_x), a_y), a_z), f_x), f_y), f_z)| {
 
                 let mass_simd = f32x4::from([masses[0], masses[1], masses[2], masses[3]]);
                 let inv_mass = f32x4::splat(1.0) / mass_simd;
 
                 // Load forces
-                let mut f_x = f32x4::from([forces[0].x, forces[1].x, forces[2].x, forces[3].x]);
-                let mut f_y = f32x4::from([forces[0].y, forces[1].y, forces[2].y, forces[3].y]);
-                let mut f_z = f32x4::from([forces[0].z, forces[1].z, forces[2].z, forces[3].z]);
+                let mut simd_f_x = f32x4::from([f_x[0], f_x[1], f_x[2], f_x[3]]);
+                let mut simd_f_y = f32x4::from([f_y[0], f_y[1], f_y[2], f_y[3]]);
+                let mut simd_f_z = f32x4::from([f_z[0], f_z[1], f_z[2], f_z[3]]);
 
                 // Apply gravity (F = F + mg)
-                f_x = f_x + (grav_x * mass_simd);
-                f_y = f_y + (grav_y * mass_simd);
-                f_z = f_z + (grav_z * mass_simd);
+                simd_f_x += grav_x * mass_simd;
+                simd_f_y += grav_y * mass_simd;
+                simd_f_z += grav_z * mass_simd;
 
                 // Calculate acceleration (a = F / m)
-                let a_x = f_x * inv_mass;
-                let a_y = f_y * inv_mass;
-                let a_z = f_z * inv_mass;
+                let simd_a_x = simd_f_x * inv_mass;
+                let simd_a_y = simd_f_y * inv_mass;
+                let simd_a_z = simd_f_z * inv_mass;
 
                 // Load velocities
-                let mut v_x = f32x4::from([velocities[0].x, velocities[1].x, velocities[2].x, velocities[3].x]);
-                let mut v_y = f32x4::from([velocities[0].y, velocities[1].y, velocities[2].y, velocities[3].y]);
-                let mut v_z = f32x4::from([velocities[0].z, velocities[1].z, velocities[2].z, velocities[3].z]);
+                let mut simd_v_x = f32x4::from([v_x[0], v_x[1], v_x[2], v_x[3]]);
+                let mut simd_v_y = f32x4::from([v_y[0], v_y[1], v_y[2], v_y[3]]);
+                let mut simd_v_z = f32x4::from([v_z[0], v_z[1], v_z[2], v_z[3]]);
 
                 // Update velocities (v = v + a * dt)
-                v_x = v_x + (a_x * dt_simd);
-                v_y = v_y + (a_y * dt_simd);
-                v_z = v_z + (a_z * dt_simd);
+                simd_v_x += simd_a_x * dt_simd;
+                simd_v_y += simd_a_y * dt_simd;
+                simd_v_z += simd_a_z * dt_simd;
 
                 // Store back
-                let a_x_arr: [f32; 4] = a_x.into();
-                let a_y_arr: [f32; 4] = a_y.into();
-                let a_z_arr: [f32; 4] = a_z.into();
+                let a_x_arr: [f32; 4] = simd_a_x.into();
+                let a_y_arr: [f32; 4] = simd_a_y.into();
+                let a_z_arr: [f32; 4] = simd_a_z.into();
 
-                let v_x_arr: [f32; 4] = v_x.into();
-                let v_y_arr: [f32; 4] = v_y.into();
-                let v_z_arr: [f32; 4] = v_z.into();
+                let v_x_arr: [f32; 4] = simd_v_x.into();
+                let v_y_arr: [f32; 4] = simd_v_y.into();
+                let v_z_arr: [f32; 4] = simd_v_z.into();
 
                 for i in 0..4 {
-                    accelerations[i] = Vector3d::new(a_x_arr[i], a_y_arr[i], a_z_arr[i]);
-                    velocities[i] = Vector3d::new(v_x_arr[i], v_y_arr[i], v_z_arr[i]);
-                    forces[i] = Vector3d::zero();
+                    a_x[i] = a_x_arr[i];
+                    a_y[i] = a_y_arr[i];
+                    a_z[i] = a_z_arr[i];
+
+                    v_x[i] = v_x_arr[i];
+                    v_y[i] = v_y_arr[i];
+                    v_z[i] = v_z_arr[i];
+
+                    f_x[i] = 0.0;
+                    f_y[i] = 0.0;
+                    f_z[i] = 0.0;
+
+                    let vel = Vector3d::new(v_x[i], v_y[i], v_z[i]);
 
                     // Update vertices
                     for vertex in &mut shapes[i].vertices {
-                        *vertex = vertex.add(&velocities[i].scale(dt));
+                        *vertex = vertex.add(&vel.scale(dt));
                     }
                 }
             });
@@ -116,20 +118,36 @@ impl World {
             for i in start..end {
                 let mass = self.bodies.masses[i];
                 let gravity_force = crate::physics::constants::GRAVITY.scale(mass);
-                let mut force = self.bodies.forces[i].add(&gravity_force);
 
-                let accel = force.scale(1.0 / mass);
-                self.bodies.accelerations[i] = accel;
+                let mut current_force = Vector3d::new(
+                    self.bodies.forces_x[i],
+                    self.bodies.forces_y[i],
+                    self.bodies.forces_z[i]
+                ).add(&gravity_force);
 
-                let mut velocity = self.bodies.velocities[i];
-                velocity = velocity.add(&accel.scale(dt));
-                self.bodies.velocities[i] = velocity;
+                let accel = current_force.scale(1.0 / mass);
+                self.bodies.accelerations_x[i] = accel.x;
+                self.bodies.accelerations_y[i] = accel.y;
+                self.bodies.accelerations_z[i] = accel.z;
+
+                let mut current_vel = Vector3d::new(
+                    self.bodies.velocities_x[i],
+                    self.bodies.velocities_y[i],
+                    self.bodies.velocities_z[i]
+                );
+                current_vel = current_vel.add(&accel.scale(dt));
+
+                self.bodies.velocities_x[i] = current_vel.x;
+                self.bodies.velocities_y[i] = current_vel.y;
+                self.bodies.velocities_z[i] = current_vel.z;
 
                 for vertex in &mut self.bodies.shapes[i].vertices {
-                    *vertex = vertex.add(&velocity.scale(dt));
+                    *vertex = vertex.add(&current_vel.scale(dt));
                 }
 
-                self.bodies.forces[i] = Vector3d::zero();
+                self.bodies.forces_x[i] = 0.0;
+                self.bodies.forces_y[i] = 0.0;
+                self.bodies.forces_z[i] = 0.0;
             }
         }
 
@@ -143,11 +161,19 @@ impl World {
                 if self.bodies.shapes[i].vertices.is_empty() || self.bodies.shapes[j].vertices.is_empty() { continue; }
 
                 let p1 = self.bodies.shapes[i].vertices[0];
-                let v1 = self.bodies.velocities[i];
+                let mut v1 = Vector3d::new(
+                    self.bodies.velocities_x[i],
+                    self.bodies.velocities_y[i],
+                    self.bodies.velocities_z[i]
+                );
                 let r1 = 1.0; // Approximation
 
                 let p2 = self.bodies.shapes[j].vertices[0];
-                let v2 = self.bodies.velocities[j];
+                let mut v2 = Vector3d::new(
+                    self.bodies.velocities_x[j],
+                    self.bodies.velocities_y[j],
+                    self.bodies.velocities_z[j]
+                );
                 let r2 = 1.0; // Approximation
 
                 if let Some(toi) = calculate_toi_sphere_sphere(p1, v1, r1, p2, v2, r2, dt) {
@@ -156,14 +182,20 @@ impl World {
                     // A full solver would compute collision response at TOI.
                     let collision_normal = (p1.add(&v1.scale(toi * dt))).subtract(&p2.add(&v2.scale(toi * dt))).normalize();
 
-                    let v1_proj = self.bodies.velocities[i].dot(&collision_normal);
-                    let v2_proj = self.bodies.velocities[j].dot(&collision_normal);
+                    let v1_proj = v1.dot(&collision_normal);
+                    let v2_proj = v2.dot(&collision_normal);
 
                     if v1_proj < 0.0 {
-                        self.bodies.velocities[i] = self.bodies.velocities[i].subtract(&collision_normal.scale(v1_proj));
+                        v1 = v1.subtract(&collision_normal.scale(v1_proj));
+                        self.bodies.velocities_x[i] = v1.x;
+                        self.bodies.velocities_y[i] = v1.y;
+                        self.bodies.velocities_z[i] = v1.z;
                     }
                     if v2_proj > 0.0 {
-                        self.bodies.velocities[j] = self.bodies.velocities[j].subtract(&collision_normal.scale(v2_proj));
+                        v2 = v2.subtract(&collision_normal.scale(v2_proj));
+                        self.bodies.velocities_x[j] = v2.x;
+                        self.bodies.velocities_y[j] = v2.y;
+                        self.bodies.velocities_z[j] = v2.z;
                     }
                 }
             }


### PR DESCRIPTION
This PR completes the state-of-the-art (SOTA) goals by fully transitioning the core physics engine to a pure Structure of Arrays (SoA) memory layout while addressing multiple compilation errors.

Key changes:
- `RigidBodyComponents` now maintains individual flat `Vec<f32>` arrays for coordinates (e.g., `velocities_x`, `velocities_y`, etc.) instead of wrapping `Vector3d` elements.
- Cleaned up the `World` struct, properly utilizing `RigidBodyComponents` for the SoA implementation.
- Refactored multithreaded iterations (`World::step()`) using `rayon` by leveraging chained `.par_chunks_mut(chunk_size).zip(...)` instead of iterating tuples.
- Optimized SIMD vectorization utilizing `wide::f32x4` over flat SoA slices instead of non-performant AoS approaches, fully bypassing mathematical overhead on individual vectors.
- Reverted the `Vector3d` primitive back to using scalar instructions internally, resolving `E0425` and `E0433` macro errors and ensuring stability.
- Addressed assorted compiler warnings (e.g., unused variable in the WGPU pipeline code, mutable bindings, and unused imports).

---
*PR created automatically by Jules for task [16173481534938106573](https://jules.google.com/task/16173481534938106573) started by @DanielMarcos1*