### PR TITLE
Add Strategic Portfolio Plan for Worm Engine SOTA Expansion

### DIFF
--- a/ISSUE_SOTA_PLAN.md
+++ b/ISSUE_SOTA_PLAN.md
@@ -1,0 +1,45 @@
+---
+name: "Worm Engine SOTA Plan"
+title: "Elevate Worm Engine to SOTA Level"
+labels: ["strategic", "portfolio", "sota"]
+---
+
+# Strategic Portfolio Plan: Worm Engine v1.0.0 & SOTA Expansion
+
+## Executive Summary
+**Strategic Objectives**: Evolve the Worm Engine from a functional 3D physics engine into a state-of-the-art, high-performance solution capable of capturing top-tier market share in the simulation and gaming sectors.
+**Portfolio Value**: Expected 25%+ portfolio ROI through successful integration of core and SOTA functionality. Maintaining 95% on-time delivery across all milestones.
+**Market Opportunity**: The 3D physics engine landscape demands hyper-performance, memory efficiency, and deterministic simulation to meet modern ECS-native engines (e.g., Bevy, Flecs) and AAA physics standards.
+**Resource Strategy**: Allocate specialized engineering resources (Physics Engineer, Architecture Lead, Systems Engineer, Graphics Engineer) to high-impact R&D, structural refactoring, and deterministic math optimizations.
+
+## Project Portfolio Overview
+
+**Tier 1 Projects** (Strategic Priority):
+- Task 1: Continuous Collision Detection (CCD): Integrated into v0.4.0. Expected ROI aligns with securing high-speed simulation markets. Strategic Impact: Prevent "tunneling" at high velocities.
+- Continuous Collision Detection (CCD) needs to be resolved/issued/tested by the Physics Engineer. Success measured by 0% tunneling at velocities up to 1000m/s.
+
+- Task 2: Data-Oriented Design (DOD) & ECS Refactoring: Integrated into v0.6.0. Expected ROI aligns with modern ECS adoption. Strategic Impact: Memory layout optimized for cache coherency and ECS compatibility.
+- Data-Oriented Design (DOD) & ECS Refactoring needs to be resolved/issued/tested by the Architecture Lead. Success measured by API integration with a standard ECS in under 2 hours.
+
+- Task 3 & 4: Multithreading and SIMD Vectorization Implementation: Integrated into v0.6.0. Expected ROI aligns with performance leadership. Strategic Impact: Engine scales linearly up to 16 threads and core math operations utilize SIMD instructions using SoA approach.
+- Multithreading Implementation needs to be resolved/issued/tested by the Systems Engineer. SIMD Vectorization Implementation needs to be resolved/issued/tested by the Systems Engineer. Engine scales linearly up to 16 threads on supported hardware.
+
+**Tier 2 Projects** (Growth Initiatives):
+- Task 5: Cross-Platform Determinism Setup: Integrated into v0.7.0/v1.0.0. Expected ROI aligns with competitive multiplayer market positioning. Market Impact: Ensure strict floating-point math control and deterministic solver execution across multiple architectures using `libm`.
+- Cross-Platform Determinism Setup needs to be resolved/issued/tested by the Systems Engineer. Dependencies: Simulation must yield identical results across different CPU architectures.
+
+**Innovation Pipeline**:
+- Task 6: GPU Acceleration (Compute Shaders) Integration: Integrated into v0.8.0/v1.0.0.
+- GPU Acceleration (Compute Shaders) Integration needs to be resolved/issued/tested by the Graphics Engineer. Integrate `wgpu` (~v0.19) and WGSL for GPU-accelerated compute shaders targeting massive scale simulations.
+
+## Resource Allocation Strategy
+**Team Capacity**: Allocating roles across R&D including Physics Engineer, Architecture Lead, Systems Engineer, and Graphics Engineer. Focus on actionable development tasks (30-60 minutes each).
+**Skill Development**: Upskill team in `rayon` for task-based parallelism, `wide` for SIMD operations, `libm` for deterministic operations, and `wgpu` for GPU compute acceleration.
+**External Partners**: Engage with Rust game engine maintainers for early integration testing of our DOD API and deterministic behavior checks.
+**Budget Distribution**: Front-load investment in architectural DOD and ECS refactoring before advancing to SIMD and GPU acceleration tasks.
+
+## Risk Management and Contingency
+**Portfolio Risks**: Scope creep with GPU/CCD features risking the v1.0.0 delivery timeline. 16-byte memory alignment crashes when interfacing with WGSL.
+**Mitigation Strategies**: Modularize GPU/CCD features as optional add-ons to not block v1.0.0 core deliveries. Use flat `array<f32>` and Rust structs with `#[repr(C)]`, `Pod`, and `Zeroable` to prevent memory alignment issues.
+**Contingency Planning**: Defer SIMD vectorization until DOD refactoring is complete to use a Structure of Arrays (SoA) approach. Provide fallback mechanisms for non-deterministic math.
+**Success Metrics**: Ensure 25%+ portfolio ROI and 95% on-time delivery across core engine deliveries.


### PR DESCRIPTION
This commit adds a new GitHub issue file `ISSUE_SOTA_PLAN.md` representing a strategic portfolio plan. This was drafted following the Studio Producer persona requirements, using the provided template, focusing on elevating the Worm Engine to State-of-the-Art level as detailed in the internal task lists and specifications. It includes success metrics, task-role assignments, and R&D capability details while maintaining constraints on testing steps.

---
*PR created automatically by Jules for task [12140227401763499791](https://jules.google.com/task/12140227401763499791) started by @DanielMarcos1*