### PR TITLE
Create PM tasklist mapping tasks to agency roles

### DIFF
--- a/ai/memory-bank/tasks/worm-engine-tasklist.md
+++ b/ai/memory-bank/tasks/worm-engine-tasklist.md
@@ -1,13 +1,13 @@
 # Worm Engine Development Tasks
 
 ## Specification Summary
-**Original Requirements**: "Evolve the Worm Engine from a functional 3D physics engine into a state-of-the-art, high-performance solution capable of capturing top-tier market share in the simulation and gaming sectors."
-**Technical Stack**: Rust, rayon, wide, libm, wgpu (~v0.19), WGSL
-**Target Timeline**: Integrated into v0.4.0 (CCD), v0.6.0 (DOD, SIMD), v0.7.0/v1.0.0 (Determinism), and v0.8.0/v1.0.0 (GPU) while maintaining 95% on-time delivery benchmark for the current roadmap milestones.
+**Original Requirements**: Expand scope to include Tier 1 State-of-the-Art (SOTA) initiatives—Continuous Collision Detection (CCD), DOD/ECS compatibility, and Multithreading/SIMD—and Tier 2 Experimental growth initiatives—Cross-Platform Determinism and GPU Acceleration.
+**Technical Stack**: Rust, rayon, wide, libm, wgpu, wgsl
+**Target Timeline**: v1.0.0 Roadmap (Current features are on v0.4.0 to v0.7.0/1.0.0 tracks based on SOTA Scope Issue)
 
 ## Development Tasks
 
-### [ ] Task 1: Continuous Collision Detection (CCD)
+### [ ] Task 1: Continuous Collision Detection (CCD) Implementation
 **Description**: Implement Continuous Collision Detection to prevent "tunneling" at high velocities. This involves calculating time of impact (TOI) between moving bodies.
 **Acceptance Criteria**:
 - 0% tunneling observed at velocities up to 1000m/s.
@@ -19,10 +19,10 @@
 - src/physics/mod.rs
 - src/physics/world.rs
 
-**Reference**: Issue Task 1 CCD
-**Assignment**: Physics Engineer needs to resolve/issue/test this feature.
+**Reference**: Tier 1 Projects - Continuous Collision Detection (CCD)
+**Assignment**: Continuous Collision Detection (CCD) Implementation needs to be resolved/issued/tested by the Physics Engineer
 
-### [ ] Task 2: Data-Oriented Design (DOD) & ECS Refactoring (30-60 minutes)
+### [ ] Task 2: Data-Oriented Design (DOD) & ECS Refactoring
 **Description**: Refactor core engine structures to support Data-Oriented Design, making it compatible with modern ECS architectures like Bevy and Flecs.
 **Acceptance Criteria**:
 - Memory layout is optimized for cache coherency.
@@ -34,38 +34,25 @@
 - src/physics/world.rs
 - src/physics/components.rs
 
-**Reference**: Issue Task 2 DOD
-**Assignment**: Architecture Lead needs to resolve/issue/test this feature.
+**Reference**: Tier 1 Projects - Data-Oriented Design (DOD) & ECS Compatibility
+**Assignment**: Data-Oriented Design (DOD) & ECS Refactoring needs to be resolved/issued/tested by the Architecture Lead
 
-### [ ] Task 3: Multithreading Implementation
-**Description**: Integrate `rayon` for task-based parallelism. Refactor parallel iteration over large mutable SoA arrays in `World::step` to chain `.par_iter_mut().zip(...)` instead of passing tuples.
+### [ ] Task 3: Multithreading and SIMD Vectorization
+**Description**: Integrate `rayon` for task-based parallelism and `wide` (replacing std::simd) for vectorizing math operations in the physics pipeline.
 **Acceptance Criteria**:
 - Engine scales linearly up to 16 threads on supported hardware.
-- Thread synchronization does not introduce unresolvable latency.
-- SIMD vectorization utilizes a Structure of Arrays (SoA) approach rather than AoS on individual math primitives.
-
-**Files to Create/Edit**:
-- Cargo.toml
-- src/physics/world.rs
-
-**Reference**: Issue Task 3 SIMD (Part 1 - Rayon)
-**Assignment**: Systems Engineer needs to resolve/issue/test this feature.
-
-### [ ] Task 4: SIMD Vectorization Implementation
-**Description**: Integrate `wide` for vectorizing math operations in the physics pipeline. Defer until DOD refactoring is complete to use a Structure of Arrays (SoA) approach. Avoid applying Array of Structures (AoS) SIMD to individual math primitives like `Vector3d`.
-**Acceptance Criteria**:
 - Core math operations (vector additions, dot products, cross products) utilize SIMD instructions.
-- SIMD implementation leverages SoA approach exclusively without overhead on individual primitives.
+- Thread synchronization does not introduce unresolvable latency.
 
 **Files to Create/Edit**:
 - Cargo.toml
 - src/geometry/vector.rs
 - src/physics/world.rs
 
-**Reference**: Issue Task 3 SIMD (Part 2 - SIMD)
-**Assignment**: Systems Engineer needs to resolve/issue/test this feature.
+**Reference**: Tier 1 Projects - Multithreading and SIMD Vectorization
+**Assignment**: Multithreading and SIMD Vectorization needs to be resolved/issued/tested by the Systems Engineer
 
-### [ ] Task 5: Cross-Platform Determinism Setup
+### [ ] Task 4: Cross-Platform Determinism Setup
 **Description**: Implement strict floating-point math control and deterministic solver execution across multiple architectures using `libm`.
 **Acceptance Criteria**:
 - Simulation yields identical results across different CPU architectures.
@@ -75,33 +62,35 @@
 **Files to Create/Edit**:
 - src/physics/math.rs
 - src/physics/constants.rs
+- Tests related to cross-platform execution.
 
-**Reference**: Issue Task 4 Determinism
-**Assignment**: Systems Engineer needs to resolve/issue/test this feature.
+**Reference**: Tier 2 Projects - Cross-Platform Determinism
+**Assignment**: Cross-Platform Determinism Setup needs to be resolved/issued/tested by the Systems Engineer
 
-### [ ] Task 6: GPU Acceleration (Compute Shaders) Integration
-**Description**: Integrate `wgpu` (~v0.19) for GPU-accelerated compute shaders targeting massive scale simulations. `Vector3d` sent via `bytemuck` must use `#[repr(C)]` with `Pod` and `Zeroable` derives. In WGSL, use a flat `array<f32>` (indexing by 3) instead of `array<vec3<f32>>`.
+### [ ] Task 5: GPU Acceleration (Compute Shaders) Integration
+**Description**: Future-proof the engine by integrating WGPU for GPU-accelerated compute shaders, initially targeting massive scale simulations like soft-bodies or fluids.
 **Acceptance Criteria**:
 - Basic WGPU context is established and integrated into the build.
 - A prototype compute shader runs and passes data back to the CPU physics pipeline.
-- CPU pipeline remains stable during GPU execution with no 16-byte memory alignment crashes.
+- CPU pipeline remains stable during GPU execution.
 
 **Files to Create/Edit**:
 - Cargo.toml
 - src/physics/gpu.rs
 - shaders/compute.wgsl
 
-**Reference**: Issue Task 5 GPU
-**Assignment**: Graphics Engineer needs to resolve/issue/test this feature.
+**Reference**: Tier 2 Projects - GPU Acceleration (Compute Shaders)
+**Assignment**: GPU Acceleration (Compute Shaders) Integration needs to be resolved/issued/tested by the Graphics Engineer
 
 ## Quality Requirements
-- [ ] Must pass `cargo check` cleanly
-- [ ] Must pass `cargo test` suite
 - [ ] No background processes in any commands - NEVER append `&`
-- [ ] Iterating multiple mutable SoA arrays in `rayon` must chain `.par_iter_mut().zip(...)`
-- [ ] WGSL shaders must avoid 16-byte alignment crashes by using flat `array<f32>` and Rust structs must use `#[repr(C)]`, `Pod`, and `Zeroable`.
+- [ ] Cargo check passes successfully: `cargo check`
+- [ ] Cargo test passes successfully without introducing regressions: `cargo test`
 
 ## Technical Notes
-**Development Stack**: Rust, rayon, wide, libm, wgpu (~v0.19), WGSL
-**Special Instructions**: Ensure DOD refactoring is complete before implementing SIMD vectorization to allow SoA optimization. Risk of scope creep with GPU/CCD features; modularize as optional add-ons to not block v1.0.0.
-**Timeline Expectations**: Milestones to be met for 0.4.0, 0.6.0, 0.7.0, and 0.8.0 as per strategic portfolio plan. Target 30-60 minutes maximum per actionable development task.
+**Development Stack**: Rust, rayon, wide, libm, wgpu (~v0.19) with WGSL
+**Special Instructions**:
+- Use `wide` crate (e.g., `wide::f32x4`) for SIMD operations instead of `std::simd`.
+- When iterating over multiple mutable SoA arrays in parallel with `rayon`, chain `.par_chunks_mut(4).zip(...)` or `.par_iter_mut().zip(...)` instead of passing a tuple to `.into_par_iter()`.
+- Send `Vector3d` data to WGSL via `bytemuck` using `#[repr(C)]` with `Pod` and `Zeroable` derives, and use a flat `array<f32>` (indexing by 3) in WGSL.
+**Timeline Expectations**: Modular integration required to keep the v1.0.0 roadmap moving on time.


### PR DESCRIPTION
Converted project specifications from issue documents into a standardized PM tasklist, with specific agency roles explicitly assigned to each architectural component.

---
*PR created automatically by Jules for task [10520162789923221033](https://jules.google.com/task/10520162789923221033) started by @DanielMarcos1*