### PR TITLE
Refactor DOD components to Pure SoA and SIMD multithreading loops

### DIFF
--- a/src/geometry/vector.rs
+++ b/src/geometry/vector.rs
@@ -23,36 +23,18 @@ impl Vector3d {
         }
     }
 
-    // Internal helper to get SIMD representation (padding with 0.0)
-    #[inline(always)]
-    fn to_simd(&self) -> f32x4 {
-        f32x4::new([self.x, self.y, self.z, 0.0])
-    }
-
-    // Internal helper to create Vector3d from SIMD
-    #[inline(always)]
-    fn from_simd(simd: f32x4) -> Self {
-        let arr = simd.to_array();
-        Self {
-            x: arr[0],
-            y: arr[1],
-            z: arr[2],
-        }
-    }
-
     // A vector of 3d must have basic arithmetic calculations to represent it's location on the environment
     pub fn add(&self, other: &Vector3d) -> Vector3d {
-        Self::from_simd(self.to_simd() + other.to_simd())
+        Self::new(self.x + other.x, self.y + other.y, self.z + other.z)
     }
 
     pub fn subtract(&self, other: &Vector3d) -> Vector3d {
-        Self::from_simd(self.to_simd() - other.to_simd())
+        Self::new(self.x - other.x, self.y - other.y, self.z - other.z)
     }
 
     // Scalar multiplication has the purpose to control vector speed without changing its direction
     pub fn scale(&self, scalar: f32) -> Vector3d {
-        let scalar_simd = f32x4::splat(scalar);
-        Self::from_simd(self.to_simd() * scalar_simd)
+        Self::new(self.x * scalar, self.y * scalar, self.z * scalar)
     }
 
     // This represents the length or size of the vector
@@ -72,9 +54,7 @@ impl Vector3d {
 
     // Look at where the vector is pointing at and it's relative direction compared to other vectors
     pub fn dot(&self, other: &Vector3d) -> f32 {
-        let mul = self.to_simd() * other.to_simd();
-        let arr = mul.to_array();
-        arr[0] + arr[1] + arr[2]
+        self.x * other.x + self.y * other.y + self.z * other.z
     }
 
     // This can be used to calculate many things like perpendicular directions,

--- a/src/physics/components.rs
+++ b/src/physics/components.rs
@@ -1,12 +1,18 @@
-use crate::geometry::{vector::Vector3d, polygon::Polygon};
+use crate::geometry::polygon::Polygon;
 
 #[derive(Debug, Default)]
 pub struct RigidBodyComponents {
     pub shapes: Vec<Polygon>,
     pub masses: Vec<f32>,
-    pub velocities: Vec<Vector3d>,
-    pub accelerations: Vec<Vector3d>,
-    pub forces: Vec<Vector3d>,
+    pub velocities_x: Vec<f32>,
+    pub velocities_y: Vec<f32>,
+    pub velocities_z: Vec<f32>,
+    pub accelerations_x: Vec<f32>,
+    pub accelerations_y: Vec<f32>,
+    pub accelerations_z: Vec<f32>,
+    pub forces_x: Vec<f32>,
+    pub forces_y: Vec<f32>,
+    pub forces_z: Vec<f32>,
 }
 
 impl RigidBodyComponents {
@@ -18,9 +24,18 @@ impl RigidBodyComponents {
         assert!(mass > 0.0, "Mass must be greater than zero");
         self.shapes.push(shape);
         self.masses.push(mass);
-        self.velocities.push(Vector3d::zero());
-        self.accelerations.push(Vector3d::zero());
-        self.forces.push(Vector3d::zero());
+
+        self.velocities_x.push(0.0);
+        self.velocities_y.push(0.0);
+        self.velocities_z.push(0.0);
+
+        self.accelerations_x.push(0.0);
+        self.accelerations_y.push(0.0);
+        self.accelerations_z.push(0.0);
+
+        self.forces_x.push(0.0);
+        self.forces_y.push(0.0);
+        self.forces_z.push(0.0);
     }
 
     pub fn len(&self) -> usize {

--- a/src/physics/rigid_body.rs
+++ b/src/physics/rigid_body.rs
@@ -1,28 +1,43 @@
 use crate::{geometry::vector::Vector3d, physics::{constants::GRAVITY, components::RigidBodyComponents}};
 
 pub fn apply_force(components: &mut RigidBodyComponents, index: usize, force: Vector3d) {
-    components.forces[index] = components.forces[index].add(&force);
+    components.forces_x[index] += force.x;
+    components.forces_y[index] += force.y;
+    components.forces_z[index] += force.z;
 }
 
 pub fn apply_gravity(components: &mut RigidBodyComponents, index: usize) {
     let force = GRAVITY.scale(components.masses[index]);
-    components.forces[index] = components.forces[index].add(&force);
+    components.forces_x[index] += force.x;
+    components.forces_y[index] += force.y;
+    components.forces_z[index] += force.z;
 }
 
 pub fn update(components: &mut RigidBodyComponents, index: usize, dt: f32) {
     let mass = components.masses[index];
-    let force = components.forces[index];
+    let inv_mass = 1.0 / mass;
 
-    let mut accel = force.scale(1.0 / mass);
-    components.accelerations[index] = accel;
+    // a = F / m
+    components.accelerations_x[index] = components.forces_x[index] * inv_mass;
+    components.accelerations_y[index] = components.forces_y[index] * inv_mass;
+    components.accelerations_z[index] = components.forces_z[index] * inv_mass;
 
-    let mut vel = components.velocities[index];
-    vel = vel.add(&accel.scale(dt));
-    components.velocities[index] = vel;
+    // v = v + a * dt
+    components.velocities_x[index] += components.accelerations_x[index] * dt;
+    components.velocities_y[index] += components.accelerations_y[index] * dt;
+    components.velocities_z[index] += components.accelerations_z[index] * dt;
+
+    let vel = Vector3d::new(
+        components.velocities_x[index],
+        components.velocities_y[index],
+        components.velocities_z[index],
+    );
 
     for vertex in &mut components.shapes[index].vertices {
         *vertex = vertex.add(&vel.scale(dt));
     }
 
-    components.forces[index] = Vector3d::zero();
+    components.forces_x[index] = 0.0;
+    components.forces_y[index] = 0.0;
+    components.forces_z[index] = 0.0;
 }

--- a/src/physics/world.rs
+++ b/src/physics/world.rs
@@ -8,14 +8,6 @@ pub struct World {
     pub bodies: RigidBodyComponents,
     pub time_step: f32,
     pub next_entity: usize,
-
-    // SoA (Struct of Arrays) layout for DOD
-    pub positions: Vec<Position>,
-    pub velocities: Vec<Velocity>,
-    pub accelerations: Vec<Acceleration>,
-    pub forces: Vec<Force>,
-    pub masses: Vec<Mass>,
-    pub shapes: Vec<Shape>,
     pub active_entities: Vec<bool>, // true if entity is active
 }
 
@@ -25,12 +17,6 @@ impl World {
             bodies: RigidBodyComponents::new(),
             time_step,
             next_entity: 0,
-            positions: Vec::new(),
-            velocities: Vec::new(),
-            accelerations: Vec::new(),
-            forces: Vec::new(),
-            masses: Vec::new(),
-            shapes: Vec::new(),
             active_entities: Vec::new(),
         }
     }
@@ -54,18 +40,24 @@ impl World {
         // Process in chunks of 4 for SIMD vectorization
         self.bodies.shapes[..exact_len].par_chunks_mut(chunk_size)
             .zip(self.bodies.masses[..exact_len].par_chunks_mut(chunk_size))
-            .zip(self.bodies.velocities[..exact_len].par_chunks_mut(chunk_size))
-            .zip(self.bodies.accelerations[..exact_len].par_chunks_mut(chunk_size))
-            .zip(self.bodies.forces[..exact_len].par_chunks_mut(chunk_size))
-            .for_each(|((((shapes, masses), velocities), accelerations), forces)| {
+            .zip(self.bodies.velocities_x[..exact_len].par_chunks_mut(chunk_size))
+            .zip(self.bodies.velocities_y[..exact_len].par_chunks_mut(chunk_size))
+            .zip(self.bodies.velocities_z[..exact_len].par_chunks_mut(chunk_size))
+            .zip(self.bodies.accelerations_x[..exact_len].par_chunks_mut(chunk_size))
+            .zip(self.bodies.accelerations_y[..exact_len].par_chunks_mut(chunk_size))
+            .zip(self.bodies.accelerations_z[..exact_len].par_chunks_mut(chunk_size))
+            .zip(self.bodies.forces_x[..exact_len].par_chunks_mut(chunk_size))
+            .zip(self.bodies.forces_y[..exact_len].par_chunks_mut(chunk_size))
+            .zip(self.bodies.forces_z[..exact_len].par_chunks_mut(chunk_size))
+            .for_each(|((((((((((shapes, masses), v_xs), v_ys), v_zs), a_xs), a_ys), a_zs), f_xs), f_ys), f_zs)| {
 
                 let mass_simd = f32x4::from([masses[0], masses[1], masses[2], masses[3]]);
                 let inv_mass = f32x4::splat(1.0) / mass_simd;
 
                 // Load forces
-                let mut f_x = f32x4::from([forces[0].x, forces[1].x, forces[2].x, forces[3].x]);
-                let mut f_y = f32x4::from([forces[0].y, forces[1].y, forces[2].y, forces[3].y]);
-                let mut f_z = f32x4::from([forces[0].z, forces[1].z, forces[2].z, forces[3].z]);
+                let mut f_x = f32x4::from([f_xs[0], f_xs[1], f_xs[2], f_xs[3]]);
+                let mut f_y = f32x4::from([f_ys[0], f_ys[1], f_ys[2], f_ys[3]]);
+                let mut f_z = f32x4::from([f_zs[0], f_zs[1], f_zs[2], f_zs[3]]);
 
                 // Apply gravity (F = F + mg)
                 f_x = f_x + (grav_x * mass_simd);
@@ -78,9 +70,9 @@ impl World {
                 let a_z = f_z * inv_mass;
 
                 // Load velocities
-                let mut v_x = f32x4::from([velocities[0].x, velocities[1].x, velocities[2].x, velocities[3].x]);
-                let mut v_y = f32x4::from([velocities[0].y, velocities[1].y, velocities[2].y, velocities[3].y]);
-                let mut v_z = f32x4::from([velocities[0].z, velocities[1].z, velocities[2].z, velocities[3].z]);
+                let mut v_x = f32x4::from([v_xs[0], v_xs[1], v_xs[2], v_xs[3]]);
+                let mut v_y = f32x4::from([v_ys[0], v_ys[1], v_ys[2], v_ys[3]]);
+                let mut v_z = f32x4::from([v_zs[0], v_zs[1], v_zs[2], v_zs[3]]);
 
                 // Update velocities (v = v + a * dt)
                 v_x = v_x + (a_x * dt_simd);
@@ -97,13 +89,22 @@ impl World {
                 let v_z_arr: [f32; 4] = v_z.into();
 
                 for i in 0..4 {
-                    accelerations[i] = Vector3d::new(a_x_arr[i], a_y_arr[i], a_z_arr[i]);
-                    velocities[i] = Vector3d::new(v_x_arr[i], v_y_arr[i], v_z_arr[i]);
-                    forces[i] = Vector3d::zero();
+                    a_xs[i] = a_x_arr[i];
+                    a_ys[i] = a_y_arr[i];
+                    a_zs[i] = a_z_arr[i];
 
+                    v_xs[i] = v_x_arr[i];
+                    v_ys[i] = v_y_arr[i];
+                    v_zs[i] = v_z_arr[i];
+
+                    f_xs[i] = 0.0;
+                    f_ys[i] = 0.0;
+                    f_zs[i] = 0.0;
+
+                    let vel = Vector3d::new(v_xs[i], v_ys[i], v_zs[i]);
                     // Update vertices
                     for vertex in &mut shapes[i].vertices {
-                        *vertex = vertex.add(&velocities[i].scale(dt));
+                        *vertex = vertex.add(&vel.scale(dt));
                     }
                 }
             });
@@ -116,20 +117,34 @@ impl World {
             for i in start..end {
                 let mass = self.bodies.masses[i];
                 let gravity_force = crate::physics::constants::GRAVITY.scale(mass);
-                let mut force = self.bodies.forces[i].add(&gravity_force);
+                let force = Vector3d::new(
+                    self.bodies.forces_x[i],
+                    self.bodies.forces_y[i],
+                    self.bodies.forces_z[i],
+                ).add(&gravity_force);
 
                 let accel = force.scale(1.0 / mass);
-                self.bodies.accelerations[i] = accel;
+                self.bodies.accelerations_x[i] = accel.x;
+                self.bodies.accelerations_y[i] = accel.y;
+                self.bodies.accelerations_z[i] = accel.z;
 
-                let mut velocity = self.bodies.velocities[i];
+                let mut velocity = Vector3d::new(
+                    self.bodies.velocities_x[i],
+                    self.bodies.velocities_y[i],
+                    self.bodies.velocities_z[i],
+                );
                 velocity = velocity.add(&accel.scale(dt));
-                self.bodies.velocities[i] = velocity;
+                self.bodies.velocities_x[i] = velocity.x;
+                self.bodies.velocities_y[i] = velocity.y;
+                self.bodies.velocities_z[i] = velocity.z;
 
                 for vertex in &mut self.bodies.shapes[i].vertices {
                     *vertex = vertex.add(&velocity.scale(dt));
                 }
 
-                self.bodies.forces[i] = Vector3d::zero();
+                self.bodies.forces_x[i] = 0.0;
+                self.bodies.forces_y[i] = 0.0;
+                self.bodies.forces_z[i] = 0.0;
             }
         }
 
@@ -143,11 +158,19 @@ impl World {
                 if self.bodies.shapes[i].vertices.is_empty() || self.bodies.shapes[j].vertices.is_empty() { continue; }
 
                 let p1 = self.bodies.shapes[i].vertices[0];
-                let v1 = self.bodies.velocities[i];
+                let v1 = Vector3d::new(
+                    self.bodies.velocities_x[i],
+                    self.bodies.velocities_y[i],
+                    self.bodies.velocities_z[i],
+                );
                 let r1 = 1.0; // Approximation
 
                 let p2 = self.bodies.shapes[j].vertices[0];
-                let v2 = self.bodies.velocities[j];
+                let v2 = Vector3d::new(
+                    self.bodies.velocities_x[j],
+                    self.bodies.velocities_y[j],
+                    self.bodies.velocities_z[j],
+                );
                 let r2 = 1.0; // Approximation
 
                 if let Some(toi) = calculate_toi_sphere_sphere(p1, v1, r1, p2, v2, r2, dt) {
@@ -156,14 +179,20 @@ impl World {
                     // A full solver would compute collision response at TOI.
                     let collision_normal = (p1.add(&v1.scale(toi * dt))).subtract(&p2.add(&v2.scale(toi * dt))).normalize();
 
-                    let v1_proj = self.bodies.velocities[i].dot(&collision_normal);
-                    let v2_proj = self.bodies.velocities[j].dot(&collision_normal);
+                    let v1_proj = v1.dot(&collision_normal);
+                    let v2_proj = v2.dot(&collision_normal);
 
                     if v1_proj < 0.0 {
-                        self.bodies.velocities[i] = self.bodies.velocities[i].subtract(&collision_normal.scale(v1_proj));
+                        let new_v1 = v1.subtract(&collision_normal.scale(v1_proj));
+                        self.bodies.velocities_x[i] = new_v1.x;
+                        self.bodies.velocities_y[i] = new_v1.y;
+                        self.bodies.velocities_z[i] = new_v1.z;
                     }
                     if v2_proj > 0.0 {
-                        self.bodies.velocities[j] = self.bodies.velocities[j].subtract(&collision_normal.scale(v2_proj));
+                        let new_v2 = v2.subtract(&collision_normal.scale(v2_proj));
+                        self.bodies.velocities_x[j] = new_v2.x;
+                        self.bodies.velocities_y[j] = new_v2.y;
+                        self.bodies.velocities_z[j] = new_v2.z;
                     }
                 }
             }


### PR DESCRIPTION
Refactored engine core to fully embrace pure Structure of Arrays (SoA) layout. `RigidBodyComponents` now stores arrays of primitive floats instead of arrays of 3D vectors. This enables clean, performant, wide-vectorized multithreading loops within the collision and update cycles. Additionally, resolved compilation errors by removing unsafe SIMD structures embedded inside fundamental vector math, removing redundant fields in `World`, and appropriately adapting the physics implementations `apply_force`, `apply_gravity`, and `World::step`.

---
*PR created automatically by Jules for task [7272214710350311210](https://jules.google.com/task/7272214710350311210) started by @DanielMarcos1*