### PR TITLE
docs: Create SOTA Strategic Portfolio Plan Issue

### DIFF
--- a/ISSUE_PROJECT_SCOPE_SOTA.md
+++ b/ISSUE_PROJECT_SCOPE_SOTA.md
@@ -1,0 +1,50 @@
+---
+name: Project Scope and SOTA Alignment
+title: "Strategic Portfolio Plan: Worm Engine SOTA Alignment"
+labels: ["strategic", "portfolio", "sota"]
+---
+
+# Strategic Portfolio Plan: Worm Engine v1.0.0 & SOTA Expansion
+
+## Executive Summary
+**Strategic Objectives**: Evolve the Worm Engine from a functional 3D physics engine into a state-of-the-art (SOTA), high-performance solution capable of capturing top-tier market share in the simulation and gaming sectors. Establish cross-platform determinism and competitive multiplayer readiness.
+**Portfolio Value**: Projected 35% ROI through competitive licensing and integration capabilities, ensuring we maintain our 95% on-time delivery benchmark for the 1.0.0 roadmap.
+**Market Opportunity**: The physics engine landscape demands hyper-performance, deterministic simulation, and memory efficiency. Adding these critical features positions Worm Engine perfectly for the anticipated market shift toward highly scalable, data-oriented multiplayer experiences.
+**Resource Strategy**: Mobilize senior systems programming talent and optimize R&D budget for advanced physics algorithms, Data-Oriented Design (DOD) refactoring, and Rust-native optimizations (e.g., SIMD via `wide` crate, Multithreading via `rayon`).
+
+## Project Portfolio Overview
+**Tier 1 Projects** (Strategic Priority):
+- **Continuous Collision Detection (CCD)**: [Budget: 15% R&D, Timeline: v0.4.0, Expected ROI: 20% market share increase, Strategic Impact: Prevents "tunneling" at high velocities. Critical for fast-paced action titles and AAA adoption.]
+- *Resource allocation and success metrics*: Assigned to Physics Engineer. Success measured by 0% tunneling at 1000m/s velocities.
+
+- **Data-Oriented Design (DOD) & ECS Refactoring**: [Budget: 25% R&D, Timeline: v0.6.0, Expected ROI: 40% increase in integration adoption by modern game studios, Strategic Impact: Ensures seamless integration with modern ECS architectures (Bevy, Flecs).]
+- *Resource allocation and success metrics*: Assigned to Architecture Lead. Success measured by API integration time under 2 hours.
+
+- **Multithreading Implementation**: [Budget: 15% R&D, Timeline: v0.6.0, Expected ROI: Secures performance leadership, Strategic Impact: Maximizes CPU utilization using `rayon` with proper SoA array iteration.]
+- *Resource allocation and success metrics*: Assigned to Systems Engineer. Success measured by linear scaling up to 16 threads.
+
+- **SIMD Vectorization Implementation**: [Budget: 15% R&D, Timeline: v0.6.0, Expected ROI: Solidifies competitive advantage, Strategic Impact: Vectorizes math operations exclusively using the stable `wide` crate on SoA layout (avoiding AoS SIMD).]
+- *Resource allocation and success metrics*: Assigned to Systems Engineer. Success measured by successful utilization of SIMD instructions without `std::simd` instability.
+
+**Tier 2 Projects** (Growth Initiatives):
+- **Cross-Platform Determinism Setup**: [Budget: 10% R&D, Timeline: v0.7.0/v1.0.0, Expected ROI: Enables premium competitive multiplayer market, Market Impact: Establishes strong brand positioning in esports and RTS.]
+- *Dependencies and risk assessment*: Assigned to Systems Engineer. Dependencies on strict floating-point math via `libm`. Risks include performance overhead of deterministic fallback functions.
+
+- **GPU Acceleration (Compute Shaders) Integration**: [Budget: 20% R&D, Timeline: v0.8.0/v1.0.0, Expected ROI: Future-proofs engine for massive scale simulations, Market Impact: Opens market for soft-bodies and fluid dynamics.]
+- *Dependencies and risk assessment*: Assigned to Graphics Engineer. Dependencies on `wgpu` (~v0.19) and WGSL with strict 16-byte alignment avoidance (flat `array<f32>`). Risk of scope creep.
+
+**Innovation Pipeline**:
+- [Continuous profiling and algorithm optimization.]
+- [Technology adoption of stable cross-platform abstractions to keep up with industry standards.]
+
+## Resource Allocation Strategy
+**Team Capacity**: Dedicated assignments to Physics Engineer (CCD), Architecture Lead (DOD), Systems Engineer (Multithreading, SIMD, Determinism), and Graphics Engineer (GPU). Reallocating 30% of our general R&D capacity to specialized algorithmic optimization.
+**Skill Development**: Upskilling current engineering team in advanced DOD patterns, deterministic mathematics, and stable cross-platform SIMD vectorization.
+**External Partners**: Establish strategic alliances with leading Rust game engine maintainers (e.g., Bevy community) for early integration testing and adoption.
+**Budget Distribution**: Front-loading investment in architectural refactoring (DOD) to minimize technical debt, followed by performance features (SIMD, Multithreading), and capping with experimental initiatives (GPU, Determinism).
+
+## Risk Management and Contingency
+**Portfolio Risks**: Expanding scope to include SOTA features could jeopardize the core 1.0.0 delivery timeline. Complexity of deterministic cross-platform math and WGSL alignment issues.
+**Mitigation Strategies**: Implement strict agile milestones. Ensure GPU and CCD are modularized as optional add-ons rather than hard blockers for 1.0.0 core functionality. Stick to stable crates (`wide`, `rayon`, `libm`) and avoid unstable features (`std::simd`).
+**Contingency Planning**: Fallback to single-threaded or non-SIMD execution if synchronization or compiler issues introduce latency or instability.
+**Success Metrics**: Maintain minimum 25% portfolio ROI and achieve our 95% on-time delivery benchmark for the revised features, ensuring top 3 benchmark performance among open-source Rust physics engines.


### PR DESCRIPTION
Added `ISSUE_PROJECT_SCOPE_SOTA.md` containing a strategic portfolio plan to elevate the Worm Engine to State-of-the-Art (SOTA) level. The plan leverages the 'Studio Producer' persona and outlines the technical scope, timeline, budget allocation, and risk management for core features (CCD, DOD, Multithreading, SIMD, Determinism, and GPU Acceleration).

---
*PR created automatically by Jules for task [10420747022184991267](https://jules.google.com/task/10420747022184991267) started by @DanielMarcos1*