### PR TITLE
docs: Add Strategic Portfolio Plan for SOTA Scope

### DIFF
--- a/ISSUE_MAINTAIN_SOTA_SCOPE.md
+++ b/ISSUE_MAINTAIN_SOTA_SCOPE.md
@@ -1,0 +1,44 @@
+---
+name: Strategic Portfolio Plan - Worm Engine State-of-the-Art Scope
+about: Strategic plan to maintain project scope and achieve SOTA status.
+title: 'Strategic Portfolio Plan: Worm Engine State-of-the-Art Scope'
+labels: 'strategic, portfolio'
+assignees: ''
+---
+
+# Strategic Portfolio Plan: Fiscal Year 2024
+
+## Executive Summary
+**Strategic Objectives**: Maintain strict project scope alignment while evolving the Worm Engine into a State-of-the-Art (SOTA) 3D physics solution. Secure integration capabilities with modern game engine architectures (Bevy, Flecs) while hitting baseline roadmap targets.
+**Portfolio Value**: Projected 35% ROI driven by capturing the high-performance Rust ecosystem market, specifically simulation and ECS-native game development. Assumes total investment within current allocated R&D thresholds.
+**Market Opportunity**: Top 3 benchmark performance among open-source Rust physics engines. Competitive positioning capitalizes on the market shift towards high-concurrency, determinism, and data-oriented structures missing in legacy solutions.
+**Resource Strategy**: Dedicate up to 30% of R&D capacity directly to SOTA initiatives. Upskill the engineering team in Data-Oriented Design (DOD) and deterministic solvers. Foster strategic partnerships for integration testing.
+
+## Project Portfolio Overview
+**Tier 1 Projects** (Strategic Priority):
+- Data-Oriented Design (DOD) & ECS Compatibility: [Budget: 25% R&D, Timeline: v0.6.0, Expected ROI: 40% integration adoption increase, Strategic Impact: Critical enabling architecture]
+  - Architecture Lead to complete SOA refactoring. Success metric: under 2 hours integration time.
+- Continuous Collision Detection (CCD): [Budget: 15% R&D, Timeline: v0.4.0, Expected ROI: 20% high-speed market share, Strategic Impact: Eliminates tunneling]
+  - Physics Engineer to implement. Success metric: 0% tunneling at 1000m/s.
+- Multithreading and SIMD Vectorization: [Budget: 20% R&D, Timeline: v0.6.0, Expected ROI: Performance leadership, Strategic Impact: Scales to 16 threads]
+  - Systems Engineer to integrate `rayon` and `wide`.
+
+**Tier 2 Projects** (Growth Initiatives):
+- Cross-Platform Determinism: [Budget: 10% R&D, Timeline: v0.7.0/v1.0.0, Expected ROI: 15% premium licensing, Market Impact: Enables competitive multiplayer]
+  - Systems Engineer to implement fallback mechanisms. Risk of extended scope.
+
+**Innovation Pipeline**:
+- GPU Acceleration (Compute Shaders):
+  - Graphics Engineer to experiment with WGPU. Learning objective is massive scale capability (fluids/soft-bodies). Not allowed to block v1.0.0.
+
+## Resource Allocation Strategy
+**Team Capacity**: Cross-functional task forces centered around CCD (Physics Engineer), Architecture (Architecture Lead), and Scale (Systems Engineer).
+**Skill Development**: Targeted learning for DOD layout transitions and WGPU memory alignments (e.g., avoiding 16-byte WGSL padding crashes).
+**External Partners**: Active engagement with Bevy community maintainers.
+**Budget Distribution**: Front-loaded investment into DOD to reduce friction for subsequent multithreading and SIMD steps.
+
+## Risk Management and Contingency
+**Portfolio Risks**: Scope creep from advanced features (especially Determinism and GPU) delaying the v1.0.0 core roadmap.
+**Mitigation Strategies**: Strict modularity. Treat SOTA features as "add-ons". If they lag, decouple them from the main release cadence.
+**Contingency Planning**: Revert to single-threaded or discrete collision paths if parallel synchronization logic or CCD calculations introduce unacceptable overhead or delays.
+**Success Metrics**: Maintain >25% portfolio ROI, ensure 95% on-time delivery for base milestones, and secure top 3 performance benchmark ranking.


### PR DESCRIPTION
Created `ISSUE_MAINTAIN_SOTA_SCOPE.md` adopting the "Studio Producer" persona to outline the strategic portfolio plan for maintaining project scope while evolving the Worm Engine to state-of-the-art.

---
*PR created automatically by Jules for task [3614106151123944095](https://jules.google.com/task/3614106151123944095) started by @DanielMarcos1*