### PR TITLE
Refactor Vector3d for DOD and update PM Tasklist Roles

### DIFF
--- a/ai/memory-bank/tasks/worm-engine-tasklist.md
+++ b/ai/memory-bank/tasks/worm-engine-tasklist.md
@@ -20,7 +20,7 @@
 - src/physics/world.rs
 
 **Reference**: Issue Task 1 CCD
-**Assignment**: Physics Engineer needs to resolve/issue/test this feature.
+**Assignment**: [Task 1: Continuous Collision Detection (CCD)] needs to be resolved/issued/tested by the [Physics Engineer]
 
 ### [ ] Task 2: Data-Oriented Design (DOD) & ECS Refactoring (30-60 minutes)
 **Description**: Refactor core engine structures to support Data-Oriented Design, making it compatible with modern ECS architectures like Bevy and Flecs.
@@ -35,7 +35,7 @@
 - src/physics/components.rs
 
 **Reference**: Issue Task 2 DOD
-**Assignment**: Architecture Lead needs to resolve/issue/test this feature.
+**Assignment**: [Task 2: Data-Oriented Design (DOD) & ECS Refactoring] needs to be resolved/issued/tested by the [Architecture Lead]
 
 ### [ ] Task 3: Multithreading Implementation
 **Description**: Integrate `rayon` for task-based parallelism. Refactor parallel iteration over large mutable SoA arrays in `World::step` to chain `.par_iter_mut().zip(...)` instead of passing tuples.
@@ -49,7 +49,7 @@
 - src/physics/world.rs
 
 **Reference**: Issue Task 3 SIMD (Part 1 - Rayon)
-**Assignment**: Systems Engineer needs to resolve/issue/test this feature.
+**Assignment**: [Task 3: Multithreading Implementation] needs to be resolved/issued/tested by the [Systems Engineer]
 
 ### [ ] Task 4: SIMD Vectorization Implementation
 **Description**: Integrate `wide` for vectorizing math operations in the physics pipeline. Defer until DOD refactoring is complete to use a Structure of Arrays (SoA) approach. Avoid applying Array of Structures (AoS) SIMD to individual math primitives like `Vector3d`.
@@ -63,7 +63,7 @@
 - src/physics/world.rs
 
 **Reference**: Issue Task 3 SIMD (Part 2 - SIMD)
-**Assignment**: Systems Engineer needs to resolve/issue/test this feature.
+**Assignment**: [Task 4: SIMD Vectorization Implementation] needs to be resolved/issued/tested by the [Systems Engineer]
 
 ### [ ] Task 5: Cross-Platform Determinism Setup
 **Description**: Implement strict floating-point math control and deterministic solver execution across multiple architectures using `libm`.
@@ -77,7 +77,7 @@
 - src/physics/constants.rs
 
 **Reference**: Issue Task 4 Determinism
-**Assignment**: Systems Engineer needs to resolve/issue/test this feature.
+**Assignment**: [Task 5: Cross-Platform Determinism Setup] needs to be resolved/issued/tested by the [Systems Engineer]
 
 ### [ ] Task 6: GPU Acceleration (Compute Shaders) Integration
 **Description**: Integrate `wgpu` (~v0.19) for GPU-accelerated compute shaders targeting massive scale simulations. `Vector3d` sent via `bytemuck` must use `#[repr(C)]` with `Pod` and `Zeroable` derives. In WGSL, use a flat `array<f32>` (indexing by 3) instead of `array<vec3<f32>>`.
@@ -92,7 +92,7 @@
 - shaders/compute.wgsl
 
 **Reference**: Issue Task 5 GPU
-**Assignment**: Graphics Engineer needs to resolve/issue/test this feature.
+**Assignment**: [Task 6: GPU Acceleration (Compute Shaders) Integration] needs to be resolved/issued/tested by the [Graphics Engineer]
 
 ## Quality Requirements
 - [ ] Must pass `cargo check` cleanly

--- a/src/geometry/vector.rs
+++ b/src/geometry/vector.rs
@@ -23,36 +23,20 @@ impl Vector3d {
         }
     }
 
-    // Internal helper to get SIMD representation (padding with 0.0)
-    #[inline(always)]
-    fn to_simd(&self) -> f32x4 {
-        f32x4::new([self.x, self.y, self.z, 0.0])
-    }
 
-    // Internal helper to create Vector3d from SIMD
-    #[inline(always)]
-    fn from_simd(simd: f32x4) -> Self {
-        let arr = simd.to_array();
-        Self {
-            x: arr[0],
-            y: arr[1],
-            z: arr[2],
-        }
-    }
 
     // A vector of 3d must have basic arithmetic calculations to represent it's location on the environment
     pub fn add(&self, other: &Vector3d) -> Vector3d {
-        Self::from_simd(self.to_simd() + other.to_simd())
+        Vector3d::new(self.x + other.x, self.y + other.y, self.z + other.z)
     }
 
     pub fn subtract(&self, other: &Vector3d) -> Vector3d {
-        Self::from_simd(self.to_simd() - other.to_simd())
+        Vector3d::new(self.x - other.x, self.y - other.y, self.z - other.z)
     }
 
     // Scalar multiplication has the purpose to control vector speed without changing its direction
     pub fn scale(&self, scalar: f32) -> Vector3d {
-        let scalar_simd = f32x4::splat(scalar);
-        Self::from_simd(self.to_simd() * scalar_simd)
+        Vector3d::new(self.x * scalar, self.y * scalar, self.z * scalar)
     }
 
     // This represents the length or size of the vector
@@ -72,9 +56,7 @@ impl Vector3d {
 
     // Look at where the vector is pointing at and it's relative direction compared to other vectors
     pub fn dot(&self, other: &Vector3d) -> f32 {
-        let mul = self.to_simd() * other.to_simd();
-        let arr = mul.to_array();
-        arr[0] + arr[1] + arr[2]
+        self.x * other.x + self.y * other.y + self.z * other.z
     }
 
     // This can be used to calculate many things like perpendicular directions,

--- a/src/physics/world.rs
+++ b/src/physics/world.rs
@@ -4,6 +4,14 @@ use wide::f32x4;
 use crate::geometry::vector::Vector3d;
 use crate::physics::ccd::calculate_toi_sphere_sphere;
 
+
+pub type Position = crate::geometry::vector::Vector3d;
+pub type Velocity = crate::geometry::vector::Vector3d;
+pub type Acceleration = crate::geometry::vector::Vector3d;
+pub type Force = crate::geometry::vector::Vector3d;
+pub type Mass = f32;
+pub type Shape = crate::geometry::polygon::Polygon;
+
 pub struct World {
     pub bodies: RigidBodyComponents,
     pub time_step: f32,


### PR DESCRIPTION
Refactors Vector3d to avoid AoS SIMD and maps PM roles to the task list.

---
*PR created automatically by Jules for task [7601844985868090096](https://jules.google.com/task/7601844985868090096) started by @DanielMarcos1*