### PR TITLE
Fix compilation errors and use wide crate

### DIFF
--- a/GITHUB_ISSUE_SOTA_SCOPE.md
+++ b/GITHUB_ISSUE_SOTA_SCOPE.md
@@ -14,7 +14,7 @@
 - **Data-Oriented Design (DOD) & ECS Compatibility**: [Budget: 25% R&D, Timeline: v0.6.0, Expected ROI: 40% increase in integration adoption, Strategic Impact: Ensures seamless integration with modern ECS architectures (Bevy, Flecs). Lowers the barrier to entry for strategic partners.]
 - *Resource allocation and success metrics*: 1 architecture lead; success measured by API integration time under 2 hours. Front-loading investment to minimize technical debt.
 
-- **Multithreading and SIMD Vectorization**: [Budget: 20% R&D, Timeline: v0.6.0, Expected ROI: Secures performance leadership, Strategic Impact: Maximizes CPU utilization using `rayon` and `std::simd`. Essential to compete with Havok/Jolt.]
+- **Multithreading and SIMD Vectorization**: [Budget: 20% R&D, Timeline: v0.6.0, Expected ROI: Secures performance leadership, Strategic Impact: Maximizes CPU utilization using `rayon` and `wide`. Essential to compete with Havok/Jolt.]
 - *Resource allocation and success metrics*: Systems Engineering team; success measured by linear scaling up to 16 threads.
 
 **Tier 2 Projects** (Growth Initiatives):

--- a/ISSUE_SCOPE_AND_SOTA.md
+++ b/ISSUE_SCOPE_AND_SOTA.md
@@ -22,7 +22,7 @@
 **Investment Focus**:
 1. **DOD & ECS Refactoring**: Front-load investment in architectural refactoring to convert core structures (e.g., rigid body updates) to flat arrays/SOA. *[Architecture Lead]*
 2. **Continuous Collision Detection (CCD)**: Develop a modular TOI calculation pipeline to eliminate tunneling at 1000m/s. *[Physics Engineer]*
-3. **Multithreading & SIMD**: Integrate `rayon` and `std::simd` to scale linearly up to 16 threads. *[Systems Engineer]*
+3. **Multithreading & SIMD**: Integrate `rayon` and `wide` to scale linearly up to 16 threads. *[Systems Engineer]*
 
 **Market Opportunities**: Achieving these Tier 1 priorities will establish the Worm Engine as a top 3 benchmark performer among open-source Rust physics engines, capturing the high-speed and ECS-native game development sectors.
 **Capability Building**: Focus on robust CI testing for cross-platform determinism and fallback mechanisms for non-deterministic math.

--- a/ISSUE_SOTA_STRATEGIC_REVIEW.md
+++ b/ISSUE_SOTA_STRATEGIC_REVIEW.md
@@ -21,7 +21,7 @@
 ## 📈 Strategic Priorities Next Period
 **Investment Focus**: Front-loading investment in architectural refactoring (DOD/ECS compatibility) to minimize technical debt.
 **Market Opportunities**: Capturing the modern Rust game engine ecosystem (Bevy, Flecs) via seamless ECS integration.
-**Capability Building**: Upskilling the engineering team in advanced DOD patterns, deterministic mathematics, and SIMD Vectorization using `rayon` and `std::simd` with linear scaling up to 16 threads.
+**Capability Building**: Upskilling the engineering team in advanced DOD patterns, deterministic mathematics, and SIMD Vectorization using `rayon` and `wide` with linear scaling up to 16 threads.
 **Partnership Development**: Establishing strategic alliances with leading Rust game engine maintainers for early integration testing and vendor relationships.
 
 ---

--- a/ISSUE_STATE_OF_THE_ART.md
+++ b/ISSUE_STATE_OF_THE_ART.md
@@ -21,7 +21,7 @@ While our current 1.0.0 roadmap (Rigid/Soft bodies, Collisions, Integrators) lay
   - *Expected ROI*: 40% increase in integration adoption by modern game studios.
 
 - **Multithreading and SIMD Vectorization**:
-  - *Strategic Impact*: Maximizes CPU utilization. Leveraging Rust's `rayon` and `std::simd` will provide the hyper-performance required to compete with industry giants (Havok, Jolt).
+  - *Strategic Impact*: Maximizes CPU utilization. Leveraging Rust's `rayon` and `wide` will provide the hyper-performance required to compete with industry giants (Havok, Jolt).
   - *Resource Allocation & Metrics*: R&D innovation pipeline budget; success measured by linear scaling up to 16 threads.
 
 ### Tier 2 Projects (Growth Initiatives):

--- a/ISSUE_TASK_3_SIMD.md
+++ b/ISSUE_TASK_3_SIMD.md
@@ -1,13 +1,13 @@
 ---
 name: Multithreading and SIMD Vectorization
-about: Integrate rayon and std::simd for performance scaling.
+about: Integrate rayon and wide for performance scaling.
 title: 'Multithreading and SIMD Vectorization'
 labels: 'performance, optimization'
 assignees: ''
 ---
 
 ## Description
-Integrate `rayon` for task-based parallelism and `std::simd` for vectorizing math operations in the physics pipeline.
+Integrate `rayon` for task-based parallelism and `wide` for vectorizing math operations in the physics pipeline.
 
 ## Acceptance Criteria
 - Engine scales linearly up to 16 threads on supported hardware.

--- a/src/geometry/vector.rs
+++ b/src/geometry/vector.rs
@@ -1,3 +1,4 @@
+use wide::f32x4;
 use bytemuck::{Pod, Zeroable};
 use crate::physics::math::DeterministicMath;
 

--- a/src/physics/gpu.rs
+++ b/src/physics/gpu.rs
@@ -118,12 +118,14 @@ impl GpuContext {
         );
 
         // Submit the commands to the queue
-        let submission_index = self.queue.submit(Some(encoder.finish()));
+        let _submission_index = self.queue.submit(Some(encoder.finish()));
 
         // Map the staging buffer so we can read it on CPU
         let buffer_slice = staging_buffer.slice(..);
         let (sender, receiver) = futures_channel::oneshot::channel();
-        buffer_slice.map_async(wgpu::MapMode::Read, move |v| sender.send(v).unwrap());
+        buffer_slice.map_async(wgpu::MapMode::Read, move |v| {
+            let _ = sender.send(v);
+        });
 
         // Wait for mapping to finish
         self.device.poll(wgpu::PollType::Wait {

--- a/src/physics/rigid_body.rs
+++ b/src/physics/rigid_body.rs
@@ -13,7 +13,7 @@ pub fn update(components: &mut RigidBodyComponents, index: usize, dt: f32) {
     let mass = components.masses[index];
     let force = components.forces[index];
 
-    let mut accel = force.scale(1.0 / mass);
+    let accel = force.scale(1.0 / mass);
     components.accelerations[index] = accel;
 
     let mut vel = components.velocities[index];

--- a/src/physics/world.rs
+++ b/src/physics/world.rs
@@ -9,13 +9,6 @@ pub struct World {
     pub time_step: f32,
     pub next_entity: usize,
 
-    // SoA (Struct of Arrays) layout for DOD
-    pub positions: Vec<Position>,
-    pub velocities: Vec<Velocity>,
-    pub accelerations: Vec<Acceleration>,
-    pub forces: Vec<Force>,
-    pub masses: Vec<Mass>,
-    pub shapes: Vec<Shape>,
     pub active_entities: Vec<bool>, // true if entity is active
 }
 
@@ -25,12 +18,6 @@ impl World {
             bodies: RigidBodyComponents::new(),
             time_step,
             next_entity: 0,
-            positions: Vec::new(),
-            velocities: Vec::new(),
-            accelerations: Vec::new(),
-            forces: Vec::new(),
-            masses: Vec::new(),
-            shapes: Vec::new(),
             active_entities: Vec::new(),
         }
     }
@@ -116,7 +103,7 @@ impl World {
             for i in start..end {
                 let mass = self.bodies.masses[i];
                 let gravity_force = crate::physics::constants::GRAVITY.scale(mass);
-                let mut force = self.bodies.forces[i].add(&gravity_force);
+                let force = self.bodies.forces[i].add(&gravity_force);
 
                 let accel = force.scale(1.0 / mass);
                 self.bodies.accelerations[i] = accel;


### PR DESCRIPTION
This pull request fixes several compilation issues in the `worm-engine` project and updates the markdown specification to use `wide` instead of `std::simd`.

### Fixes

*   Removed undefined fields in the `World` struct in `src/physics/world.rs` (`positions`, `velocities`, `accelerations`, `forces`, `masses`, `shapes`).
*   Changed `let mut force` to `let force` in the `step` method of `World` in `src/physics/world.rs`.
*   Changed `let mut accel` to `let accel` in the `update` method of `src/physics/rigid_body.rs`.
*   Changed `let submission_index` to `let _submission_index` in the `execute_compute` method of `src/physics/gpu.rs`.
*   Added `use wide::f32x4;` to `src/geometry/vector.rs` to allow it to build.

### Updates

*   Replaced occurrences of `std::simd` with `wide` in `ISSUE_SCOPE_AND_SOTA.md`, `GITHUB_ISSUE_SOTA_SCOPE.md`, `ISSUE_SOTA_STRATEGIC_REVIEW.md`, `ISSUE_STATE_OF_THE_ART.md`, and `ISSUE_TASK_3_SIMD.md` using python scripts that were subsequently removed.

---
*PR created automatically by Jules for task [14929108366729080822](https://jules.google.com/task/14929108366729080822) started by @DanielMarcos1*