### PR TITLE
fix: resolve compilation errors in physics engine

### DIFF
--- a/src/geometry/vector.rs
+++ b/src/geometry/vector.rs
@@ -1,4 +1,5 @@
 use bytemuck::{Pod, Zeroable};
+use wide::f32x4;
 use crate::physics::math::DeterministicMath;
 
 #[repr(C)]

--- a/src/physics/world.rs
+++ b/src/physics/world.rs
@@ -1,4 +1,4 @@
-use crate::{geometry::polygon::Polygon, physics::components::RigidBodyComponents, physics::rigid_body};
+use crate::{geometry::polygon::Polygon, physics::components::RigidBodyComponents};
 use rayon::prelude::*;
 use wide::f32x4;
 use crate::geometry::vector::Vector3d;
@@ -9,13 +9,6 @@ pub struct World {
     pub time_step: f32,
     pub next_entity: usize,
 
-    // SoA (Struct of Arrays) layout for DOD
-    pub positions: Vec<Position>,
-    pub velocities: Vec<Velocity>,
-    pub accelerations: Vec<Acceleration>,
-    pub forces: Vec<Force>,
-    pub masses: Vec<Mass>,
-    pub shapes: Vec<Shape>,
     pub active_entities: Vec<bool>, // true if entity is active
 }
 
@@ -25,12 +18,6 @@ impl World {
             bodies: RigidBodyComponents::new(),
             time_step,
             next_entity: 0,
-            positions: Vec::new(),
-            velocities: Vec::new(),
-            accelerations: Vec::new(),
-            forces: Vec::new(),
-            masses: Vec::new(),
-            shapes: Vec::new(),
             active_entities: Vec::new(),
         }
     }


### PR DESCRIPTION
This commit resolves the compilation errors resulting from the DOD refactoring and SIMD vectorization implementations. Specifically, it ensures the `wide::f32x4` type is correctly imported in the vector geometry module and removes redundant SoA fields from the `World` struct that are now handled by `RigidBodyComponents`.

---
*PR created automatically by Jules for task [15268241103185592727](https://jules.google.com/task/15268241103185592727) started by @DanielMarcos1*