### PR TITLE
Fix compilation errors and formalize SOTA roadmap

### DIFF
--- a/ISSUE_SOTA_STRATEGIC_REVIEW.md
+++ b/ISSUE_SOTA_STRATEGIC_REVIEW.md
@@ -1,28 +1,41 @@
-# Strategic Portfolio Review: Worm Engine SOTA Alignment
+# Strategic Portfolio Plan: Worm Engine SOTA Integration (v1.0.0 Roadmap)
 
-## 🎯 Executive Summary
-**Portfolio Performance**: Currently tracking towards 1.0.0. Core mechanics (Rigid/Soft bodies) are in progress, but we need strategic adjustments to achieve SOTA status. Expected 35% ROI.
-**Market Position**: Positioned as a Rust-native engine, but lagging behind industry giants without CCD and DOD. Adding these features positions us perfectly for the anticipated market shift toward highly scalable, data-oriented multiplayer experiences.
-**Team Performance**: Engineering resources are currently split; need focused alignment on Tier 1 projects, reallocating 30% of R&D capacity to specialized algorithmic optimization (SIMD/Multithreading).
-**Strategic Outlook**: Integrating SOTA features (CCD, DOD, SIMD, Determinism, GPU Acceleration) is critical for capturing 20-40% market share increases and achieving our strategic objective.
+## Executive Summary
+**Strategic Objectives**: Evolve the Worm Engine from a functional 3D physics engine into a state-of-the-art (SOTA), high-performance solution. Align our technical milestones to deliver hyper-performance, deterministic simulation, and memory efficiency, positioning us for the anticipated market shift toward highly scalable, data-oriented multiplayer experiences.
+**Portfolio Value**: Projected 35% ROI through competitive licensing and modular architecture. Maintains our 95% on-time delivery benchmark for the core v1.0.0 roadmap milestones.
+**Market Opportunity**: Establishes competitive advantage by securing top-tier market share in the simulation and gaming sectors. Fulfills the market demand for AAA-grade features without compromising our established release cadence.
+**Resource Strategy**: Mobilize senior systems programming talent and optimize R&D budget for advanced physics algorithms, Data-Oriented Design (DOD) refactoring, and Rust-native optimizations.
 
-## 📊 Portfolio Metrics
-**Financial Performance**: Projected 35% ROI contingent on successful integration of SOTA features without derailing the 1.0.0 roadmap. Front-loading investment in architectural refactoring to minimize technical debt and reduce long-term maintenance costs.
-**Project Delivery**: Currently aiming for 95% on-time delivery. High-risk features like CCD or GPU acceleration will be modularized as optional add-ons rather than hard blockers for 1.0.0 core functionality.
-**Innovation Pipeline**: GPU Acceleration (WGPU) and Cross-Platform Determinism are in the experimental pipeline for post-v0.6.0.
-**Client Satisfaction**: High demand for modern ECS compatibility; DOD refactoring is essential for seamless Bevy/Flecs integration, expecting a 40% increase in integration adoption by modern game studios.
+## Project Portfolio Overview
+**Tier 1 Projects** (Strategic Priority):
+- **Continuous Collision Detection (CCD)**: [Budget: 15% R&D, Timeline: v0.4.0, Expected ROI: 20% market share increase, Strategic Impact: Prevents "tunneling" at high velocities (0% tunneling at 1000m/s). Critical for fast-paced action titles and AAA adoption.]
+- *Resource allocation and success metrics*: 2 dedicated physics engineers; success measured by 0% tunneling at 1000m/s velocities. Implemented as a modular add-on to not block 1.0.0.
 
-## 🚀 Strategic Achievements
-**Market Expansion**: Identifying the need for Continuous Collision Detection to secure the high-speed simulation segment (0% tunneling at 1000m/s).
-**Creative Excellence**: Establishing a roadmap for Cross-Platform Determinism to support competitive multiplayer and rollback netcode, establishing premium brand positioning.
-**Team Development**: Upskilling current engineering team in advanced DOD patterns and deterministic mathematics.
-**Process Innovation**: Modularizing high-risk features (CCD, GPU acceleration) as optional add-ons to prevent 1.0.0 blockers while implementing strict agile milestones.
+- **Data-Oriented Design (DOD) & ECS Compatibility**: [Budget: 25% R&D, Timeline: v0.6.0, Expected ROI: 40% increase in integration adoption, Strategic Impact: Ensures seamless integration with modern ECS architectures (Bevy, Flecs). Lowers the barrier to entry for strategic partners.]
+- *Resource allocation and success metrics*: 1 architecture lead; success measured by API integration time under 2 hours. Front-loading investment to minimize technical debt.
 
-## 📈 Strategic Priorities Next Period
-**Investment Focus**: Front-loading investment in architectural refactoring (DOD/ECS compatibility) to minimize technical debt.
-**Market Opportunities**: Capturing the modern Rust game engine ecosystem (Bevy, Flecs) via seamless ECS integration.
-**Capability Building**: Upskilling the engineering team in advanced DOD patterns, deterministic mathematics, and SIMD Vectorization using `rayon` and `std::simd` with linear scaling up to 16 threads.
-**Partnership Development**: Establishing strategic alliances with leading Rust game engine maintainers for early integration testing and vendor relationships.
+- **Multithreading and SIMD Vectorization**: [Budget: 20% R&D, Timeline: v0.6.0, Expected ROI: Secures performance leadership, Strategic Impact: Maximizes CPU utilization using `rayon` and `std::simd`. Essential to compete with Havok/Jolt.]
+- *Resource allocation and success metrics*: Systems Engineering team; success measured by linear scaling up to 16 threads.
+
+**Tier 2 Projects** (Growth Initiatives):
+- **Cross-Platform Determinism**: [Budget: 10% R&D, Timeline: v0.7.0/v1.0.0, Expected ROI: 15% premium licensing increase, Market Impact: Essential for competitive multiplayer and rollback netcode. Establishes premium brand positioning.]
+- *Dependencies and risk assessment*: Strict floating-point math control and deterministic solver execution. Requires robust CI testing. Risk of extended R&D phase.
+
+**Innovation Pipeline**:
+- **GPU Acceleration (Compute Shaders)**: [Experimental initiatives with learning objectives: Future-proofing for massive scale simulations (soft-bodies, fluids) via WGPU integration.]
+- *Technology adoption and capability development*: Requires stabilization of the core CPU physics pipeline first. Risk of scope creep, thus kept modular.
+
+## Resource Allocation Strategy
+**Team Capacity**: Reallocating 30% of R&D capacity from general API design to specialized algorithmic optimization (SIMD/Multithreading) and DOD.
+**Skill Development**: Upskilling current engineering team in advanced DOD patterns and deterministic mathematics.
+**External Partners**: Establish strategic alliances with leading Rust game engine maintainers (e.g., Bevy, WGPU communities) for early integration testing.
+**Budget Distribution**: Front-loading investment in architectural refactoring (ECS compatibility) to minimize technical debt and reduce long-term maintenance costs for the remainder of the v1.0.0 roadmap.
+
+## Risk Management and Contingency
+**Portfolio Risks**: Expanding the project scope with SOTA features could jeopardize the core 1.0.0 delivery timeline and increase complexity.
+**Mitigation Strategies**: Implement strict agile milestones. High-risk features like CCD or GPU acceleration will be modularized as optional add-ons rather than hard blockers for 1.0.0 core functionality.
+**Contingency Planning**: Fallback to single-threaded, discrete collision detection if multithreading synchronization introduces unresolvable latency.
+**Success Metrics**: Maintain >25% portfolio ROI, achieve 95% on-time delivery of the 1.0.0 core features alongside revised SOTA features, and reach a top 3 benchmark performance among open-source Rust physics engines.
 
 ---
 **Studio Producer**: Executive Creative Strategist

--- a/src/geometry/vector.rs
+++ b/src/geometry/vector.rs
@@ -23,36 +23,18 @@ impl Vector3d {
         }
     }
 
-    // Internal helper to get SIMD representation (padding with 0.0)
-    #[inline(always)]
-    fn to_simd(&self) -> f32x4 {
-        f32x4::new([self.x, self.y, self.z, 0.0])
-    }
-
-    // Internal helper to create Vector3d from SIMD
-    #[inline(always)]
-    fn from_simd(simd: f32x4) -> Self {
-        let arr = simd.to_array();
-        Self {
-            x: arr[0],
-            y: arr[1],
-            z: arr[2],
-        }
-    }
-
     // A vector of 3d must have basic arithmetic calculations to represent it's location on the environment
     pub fn add(&self, other: &Vector3d) -> Vector3d {
-        Self::from_simd(self.to_simd() + other.to_simd())
+        Vector3d::new(self.x + other.x, self.y + other.y, self.z + other.z)
     }
 
     pub fn subtract(&self, other: &Vector3d) -> Vector3d {
-        Self::from_simd(self.to_simd() - other.to_simd())
+        Vector3d::new(self.x - other.x, self.y - other.y, self.z - other.z)
     }
 
     // Scalar multiplication has the purpose to control vector speed without changing its direction
     pub fn scale(&self, scalar: f32) -> Vector3d {
-        let scalar_simd = f32x4::splat(scalar);
-        Self::from_simd(self.to_simd() * scalar_simd)
+        Vector3d::new(self.x * scalar, self.y * scalar, self.z * scalar)
     }
 
     // This represents the length or size of the vector
@@ -72,9 +54,7 @@ impl Vector3d {
 
     // Look at where the vector is pointing at and it's relative direction compared to other vectors
     pub fn dot(&self, other: &Vector3d) -> f32 {
-        let mul = self.to_simd() * other.to_simd();
-        let arr = mul.to_array();
-        arr[0] + arr[1] + arr[2]
+        self.x * other.x + self.y * other.y + self.z * other.z
     }
 
     // This can be used to calculate many things like perpendicular directions,

--- a/src/physics/gpu.rs
+++ b/src/physics/gpu.rs
@@ -118,7 +118,7 @@ impl GpuContext {
         );
 
         // Submit the commands to the queue
-        let submission_index = self.queue.submit(Some(encoder.finish()));
+        let _submission_index = self.queue.submit(Some(encoder.finish()));
 
         // Map the staging buffer so we can read it on CPU
         let buffer_slice = staging_buffer.slice(..);

--- a/src/physics/rigid_body.rs
+++ b/src/physics/rigid_body.rs
@@ -13,7 +13,7 @@ pub fn update(components: &mut RigidBodyComponents, index: usize, dt: f32) {
     let mass = components.masses[index];
     let force = components.forces[index];
 
-    let mut accel = force.scale(1.0 / mass);
+    let accel = force.scale(1.0 / mass);
     components.accelerations[index] = accel;
 
     let mut vel = components.velocities[index];

--- a/src/physics/world.rs
+++ b/src/physics/world.rs
@@ -1,4 +1,4 @@
-use crate::{geometry::polygon::Polygon, physics::components::RigidBodyComponents, physics::rigid_body};
+use crate::{geometry::polygon::Polygon, physics::components::RigidBodyComponents};
 use rayon::prelude::*;
 use wide::f32x4;
 use crate::geometry::vector::Vector3d;
@@ -10,12 +10,12 @@ pub struct World {
     pub next_entity: usize,
 
     // SoA (Struct of Arrays) layout for DOD
-    pub positions: Vec<Position>,
-    pub velocities: Vec<Velocity>,
-    pub accelerations: Vec<Acceleration>,
-    pub forces: Vec<Force>,
-    pub masses: Vec<Mass>,
-    pub shapes: Vec<Shape>,
+    pub positions: Vec<Vector3d>,
+    pub velocities: Vec<Vector3d>,
+    pub accelerations: Vec<Vector3d>,
+    pub forces: Vec<Vector3d>,
+    pub masses: Vec<f32>,
+    pub shapes: Vec<Polygon>,
     pub active_entities: Vec<bool>, // true if entity is active
 }
 
@@ -116,7 +116,7 @@ impl World {
             for i in start..end {
                 let mass = self.bodies.masses[i];
                 let gravity_force = crate::physics::constants::GRAVITY.scale(mass);
-                let mut force = self.bodies.forces[i].add(&gravity_force);
+                let force = self.bodies.forces[i].add(&gravity_force);
 
                 let accel = force.scale(1.0 / mass);
                 self.bodies.accelerations[i] = accel;


### PR DESCRIPTION
This PR fixes multiple compilation errors in the Rust codebase and formalizes the SOTA integration roadmap as a strategic review document:

- **DOD Struct of Arrays (SoA) Fixes:** `src/physics/world.rs` was updated to correctly use specific data types (`Vector3d`, `f32`, `Polygon`) instead of undefined aliases left over from previous refactorings.
- **SIMD Refactoring:** Reverted naive SIMD (`f32x4`) inside individual primitive `Vector3d` operations in `src/geometry/vector.rs` back to scalar math. Doing single-element SIMD operations degrades performance and violates the overarching DOD SoA architecture, where SIMD should strictly be applied over large arrays, not single items. 
- **Warnings Fixed:** Removed unused variables and unnecessary mutability in `src/physics/gpu.rs` and `src/physics/rigid_body.rs`.
- **Project Roadmap:** Attempted to push the strategic roadmap as a GitHub issue. Falling back to the local `ISSUE_SOTA_STRATEGIC_REVIEW.md` document due to CLI restrictions.
- Confirmed that `cargo check` and `cargo test` pass successfully.

---
*PR created automatically by Jules for task [17202802185977947609](https://jules.google.com/task/17202802185977947609) started by @DanielMarcos1*