### PR TITLE
Update issue and tasklist assignment strings

### DIFF
--- a/ISSUE_TASK_1_CCD.md
+++ b/ISSUE_TASK_1_CCD.md
@@ -15,7 +15,7 @@ Implement Continuous Collision Detection to prevent "tunneling" at high velociti
 - Performance impact remains within acceptable bounds for high-speed simulations.
 
 ## Assigned Agency Role
-**Physics Engineer** needs to resolve/issue/test this feature.
+Continuous Collision Detection (CCD) Implementation needs to be resolved/issued/tested by the Physics Engineer
 
 ## Files to Create/Edit
 - src/physics/ccd.rs

--- a/ISSUE_TASK_2_DOD.md
+++ b/ISSUE_TASK_2_DOD.md
@@ -15,7 +15,7 @@ Refactor core engine structures to support Data-Oriented Design, making it compa
 - Core systems (e.g., rigid body updates) operate on flat arrays or similar DOD structures.
 
 ## Assigned Agency Role
-**Architecture Lead** needs to resolve/issue/test this feature.
+Data-Oriented Design (DOD) & ECS Refactoring needs to be resolved/issued/tested by the Architecture Lead
 
 ## Files to Create/Edit
 - src/physics/rigid_body.rs

--- a/ISSUE_TASK_3_SIMD.md
+++ b/ISSUE_TASK_3_SIMD.md
@@ -15,7 +15,7 @@ Integrate `rayon` for task-based parallelism and `std::simd` for vectorizing mat
 - Thread synchronization does not introduce unresolvable latency.
 
 ## Assigned Agency Role
-**Systems Engineer** needs to resolve/issue/test this feature.
+Multithreading and SIMD Vectorization needs to be resolved/issued/tested by the Systems Engineer
 
 ## Files to Create/Edit
 - Cargo.toml

--- a/ISSUE_TASK_4_DETERMINISM.md
+++ b/ISSUE_TASK_4_DETERMINISM.md
@@ -15,7 +15,7 @@ Implement strict floating-point math control and deterministic solver execution 
 - Fallback mechanisms for non-deterministic math functions are implemented.
 
 ## Assigned Agency Role
-**Systems Engineer** needs to resolve/issue/test this feature.
+Cross-Platform Determinism Setup needs to be resolved/issued/tested by the Systems Engineer
 
 ## Files to Create/Edit
 - src/physics/math.rs

--- a/ISSUE_TASK_5_GPU.md
+++ b/ISSUE_TASK_5_GPU.md
@@ -15,7 +15,7 @@ Future-proof the engine by integrating WGPU for GPU-accelerated compute shaders,
 - CPU pipeline remains stable during GPU execution.
 
 ## Assigned Agency Role
-**Graphics Engineer** needs to resolve/issue/test this feature.
+GPU Acceleration (Compute Shaders) Integration needs to be resolved/issued/tested by the Graphics Engineer
 
 ## Files to Create/Edit
 - Cargo.toml

--- a/ai/memory-bank/tasks/worm-engine-tasklist.md
+++ b/ai/memory-bank/tasks/worm-engine-tasklist.md
@@ -20,7 +20,7 @@
 - src/physics/world.rs
 
 **Reference**: Issue Task 1 CCD
-**Assignment**: Physics Engineer needs to resolve/issue/test this feature.
+**Assignment**: Continuous Collision Detection (CCD) needs to be resolved/issued/tested by the Physics Engineer
 
 ### [ ] Task 2: Data-Oriented Design (DOD) & ECS Refactoring (30-60 minutes)
 **Description**: Refactor core engine structures to support Data-Oriented Design, making it compatible with modern ECS architectures like Bevy and Flecs.
@@ -35,7 +35,7 @@
 - src/physics/components.rs
 
 **Reference**: Issue Task 2 DOD
-**Assignment**: Architecture Lead needs to resolve/issue/test this feature.
+**Assignment**: Data-Oriented Design (DOD) & ECS Refactoring needs to be resolved/issued/tested by the Architecture Lead
 
 ### [ ] Task 3: Multithreading Implementation
 **Description**: Integrate `rayon` for task-based parallelism. Refactor parallel iteration over large mutable SoA arrays in `World::step` to chain `.par_iter_mut().zip(...)` instead of passing tuples.
@@ -49,7 +49,7 @@
 - src/physics/world.rs
 
 **Reference**: Issue Task 3 SIMD (Part 1 - Rayon)
-**Assignment**: Systems Engineer needs to resolve/issue/test this feature.
+**Assignment**: Multithreading Implementation needs to be resolved/issued/tested by the Systems Engineer
 
 ### [ ] Task 4: SIMD Vectorization Implementation
 **Description**: Integrate `wide` for vectorizing math operations in the physics pipeline. Defer until DOD refactoring is complete to use a Structure of Arrays (SoA) approach. Avoid applying Array of Structures (AoS) SIMD to individual math primitives like `Vector3d`.
@@ -63,7 +63,7 @@
 - src/physics/world.rs
 
 **Reference**: Issue Task 3 SIMD (Part 2 - SIMD)
-**Assignment**: Systems Engineer needs to resolve/issue/test this feature.
+**Assignment**: SIMD Vectorization Implementation needs to be resolved/issued/tested by the Systems Engineer
 
 ### [ ] Task 5: Cross-Platform Determinism Setup
 **Description**: Implement strict floating-point math control and deterministic solver execution across multiple architectures using `libm`.
@@ -77,7 +77,7 @@
 - src/physics/constants.rs
 
 **Reference**: Issue Task 4 Determinism
-**Assignment**: Systems Engineer needs to resolve/issue/test this feature.
+**Assignment**: Cross-Platform Determinism Setup needs to be resolved/issued/tested by the Systems Engineer
 
 ### [ ] Task 6: GPU Acceleration (Compute Shaders) Integration
 **Description**: Integrate `wgpu` (~v0.19) for GPU-accelerated compute shaders targeting massive scale simulations. `Vector3d` sent via `bytemuck` must use `#[repr(C)]` with `Pod` and `Zeroable` derives. In WGSL, use a flat `array<f32>` (indexing by 3) instead of `array<vec3<f32>>`.
@@ -92,7 +92,7 @@
 - shaders/compute.wgsl
 
 **Reference**: Issue Task 5 GPU
-**Assignment**: Graphics Engineer needs to resolve/issue/test this feature.
+**Assignment**: GPU Acceleration (Compute Shaders) Integration needs to be resolved/issued/tested by the Graphics Engineer
 
 ## Quality Requirements
 - [ ] Must pass `cargo check` cleanly


### PR DESCRIPTION
Updated the phrasing of assignments in all issue markdown files and the central project tasklist to strictly match the requested format: "[Actual Task/Component Name] needs to be resolved/issued/tested by the [Role]". This ensures that it's explicitly clear which side of the agency is handling each task.

Also included an attempt to sync these issues to the `DanielMarcos1/worm-engine` GitHub repository using the `gh` CLI.

Replaced `**Role** needs to be resolved/issued/tested by this feature` with exactly what the task is.

---
*PR created automatically by Jules for task [7436550458651615569](https://jules.google.com/task/7436550458651615569) started by @DanielMarcos1*