### PR TITLE
docs: Add project task list from specifications

### DIFF
--- a/ai/memory-bank/tasks/worm-engine-tasklist.md
+++ b/ai/memory-bank/tasks/worm-engine-tasklist.md
@@ -1,14 +1,19 @@
 # Worm Engine Development Tasks
 
 ## Specification Summary
-**Original Requirements**: "Evolve the Worm Engine from a functional 3D physics engine into a state-of-the-art, high-performance solution capable of capturing top-tier market share in the simulation and gaming sectors."
-**Technical Stack**: Rust, rayon, wide, libm, wgpu (~v0.19), WGSL
-**Target Timeline**: Integrated into v0.4.0 (CCD), v0.6.0 (DOD, SIMD), v0.7.0/v1.0.0 (Determinism), and v0.8.0/v1.0.0 (GPU) while maintaining 95% on-time delivery benchmark for the current roadmap milestones.
+**Original Requirements**:
+- Implement Continuous Collision Detection (CCD) to prevent tunneling at high velocities (0% tunneling at 1000m/s).
+- Refactor core engine structures to support Data-Oriented Design (DOD) & ECS Compatibility (seamless Bevy/Flecs integration).
+- Integrate Multithreading and SIMD Vectorization using `rayon` and `wide` crate (`wide::f32x4` only, NO `std::simd`) for linear scaling up to 16 threads.
+- Implement Cross-Platform Determinism Setup (strict floating-point math control).
+- Future-proof with GPU Acceleration (Compute Shaders) Integration using WGPU.
+**Technical Stack**: Rust, `rayon`, `wide`, `libm`, `wgpu` (v29.0.0), WGSL
+**Target Timeline**: v0.4.0 (CCD), v0.6.0 (DOD & SIMD), v0.7.0/v1.0.0 (Determinism), Experimental (GPU).
 
 ## Development Tasks
 
-### [ ] Task 1: Continuous Collision Detection (CCD)
-**Description**: Implement Continuous Collision Detection to prevent "tunneling" at high velocities. This involves calculating time of impact (TOI) between moving bodies.
+### [ ] Task 1: Continuous Collision Detection (CCD) Implementation
+**Description**: Implement Continuous Collision Detection to prevent "tunneling" at high velocities. This involves calculating time of impact (TOI) between moving bodies. Needs to be resolved/issued/tested by the Physics Engineer.
 **Acceptance Criteria**:
 - 0% tunneling observed at velocities up to 1000m/s.
 - CCD pipeline integrates with the existing collision detection system.
@@ -19,11 +24,10 @@
 - src/physics/mod.rs
 - src/physics/world.rs
 
-**Reference**: Issue Task 1 CCD
-**Assignment**: Physics Engineer needs to resolve/issue/test this feature.
+**Reference**: Tier 1 Projects - Continuous Collision Detection (CCD)
 
-### [ ] Task 2: Data-Oriented Design (DOD) & ECS Refactoring (30-60 minutes)
-**Description**: Refactor core engine structures to support Data-Oriented Design, making it compatible with modern ECS architectures like Bevy and Flecs.
+### [ ] Task 2: Data-Oriented Design (DOD) & ECS Refactoring
+**Description**: Refactor core engine structures to support Data-Oriented Design, making it compatible with modern ECS architectures like Bevy and Flecs. Needs to be resolved/issued/tested by the Architecture Lead.
 **Acceptance Criteria**:
 - Memory layout is optimized for cache coherency.
 - API allows integration with a standard ECS in under 2 hours.
@@ -34,39 +38,24 @@
 - src/physics/world.rs
 - src/physics/components.rs
 
-**Reference**: Issue Task 2 DOD
-**Assignment**: Architecture Lead needs to resolve/issue/test this feature.
+**Reference**: Tier 1 Projects - Data-Oriented Design (DOD) & ECS Compatibility
 
-### [ ] Task 3: Multithreading Implementation
-**Description**: Integrate `rayon` for task-based parallelism. Refactor parallel iteration over large mutable SoA arrays in `World::step` to chain `.par_iter_mut().zip(...)` instead of passing tuples.
+### [ ] Task 3: Multithreading and SIMD Vectorization
+**Description**: Integrate `rayon` for task-based parallelism and `wide` for vectorizing math operations in the physics pipeline. Needs to be resolved/issued/tested by the Systems Engineer.
 **Acceptance Criteria**:
 - Engine scales linearly up to 16 threads on supported hardware.
+- Core math operations (vector additions, dot products, cross products) utilize SIMD instructions (using `wide`).
 - Thread synchronization does not introduce unresolvable latency.
-- SIMD vectorization utilizes a Structure of Arrays (SoA) approach rather than AoS on individual math primitives.
-
-**Files to Create/Edit**:
-- Cargo.toml
-- src/physics/world.rs
-
-**Reference**: Issue Task 3 SIMD (Part 1 - Rayon)
-**Assignment**: Systems Engineer needs to resolve/issue/test this feature.
-
-### [ ] Task 4: SIMD Vectorization Implementation
-**Description**: Integrate `wide` for vectorizing math operations in the physics pipeline. Defer until DOD refactoring is complete to use a Structure of Arrays (SoA) approach. Avoid applying Array of Structures (AoS) SIMD to individual math primitives like `Vector3d`.
-**Acceptance Criteria**:
-- Core math operations (vector additions, dot products, cross products) utilize SIMD instructions.
-- SIMD implementation leverages SoA approach exclusively without overhead on individual primitives.
 
 **Files to Create/Edit**:
 - Cargo.toml
 - src/geometry/vector.rs
 - src/physics/world.rs
 
-**Reference**: Issue Task 3 SIMD (Part 2 - SIMD)
-**Assignment**: Systems Engineer needs to resolve/issue/test this feature.
+**Reference**: Tier 1 Projects - Multithreading and SIMD Vectorization
 
-### [ ] Task 5: Cross-Platform Determinism Setup
-**Description**: Implement strict floating-point math control and deterministic solver execution across multiple architectures using `libm`.
+### [ ] Task 4: Cross-Platform Determinism Setup
+**Description**: Implement strict floating-point math control and deterministic solver execution across multiple architectures using `libm`. Needs to be resolved/issued/tested by the Systems Engineer.
 **Acceptance Criteria**:
 - Simulation yields identical results across different CPU architectures.
 - CI testing pipeline includes deterministic behavior checks.
@@ -75,33 +64,34 @@
 **Files to Create/Edit**:
 - src/physics/math.rs
 - src/physics/constants.rs
+- Tests related to cross-platform execution.
 
-**Reference**: Issue Task 4 Determinism
-**Assignment**: Systems Engineer needs to resolve/issue/test this feature.
+**Reference**: Tier 2 Projects - Cross-Platform Determinism
 
-### [ ] Task 6: GPU Acceleration (Compute Shaders) Integration
-**Description**: Integrate `wgpu` (~v0.19) for GPU-accelerated compute shaders targeting massive scale simulations. `Vector3d` sent via `bytemuck` must use `#[repr(C)]` with `Pod` and `Zeroable` derives. In WGSL, use a flat `array<f32>` (indexing by 3) instead of `array<vec3<f32>>`.
+### [ ] Task 5: GPU Acceleration (Compute Shaders) Integration
+**Description**: Future-proof the engine by integrating WGPU for GPU-accelerated compute shaders, initially targeting massive scale simulations like soft-bodies or fluids. Needs to be resolved/issued/tested by the Graphics Engineer.
 **Acceptance Criteria**:
 - Basic WGPU context is established and integrated into the build.
 - A prototype compute shader runs and passes data back to the CPU physics pipeline.
-- CPU pipeline remains stable during GPU execution with no 16-byte memory alignment crashes.
+- CPU pipeline remains stable during GPU execution.
 
 **Files to Create/Edit**:
 - Cargo.toml
 - src/physics/gpu.rs
 - shaders/compute.wgsl
 
-**Reference**: Issue Task 5 GPU
-**Assignment**: Graphics Engineer needs to resolve/issue/test this feature.
+**Reference**: Tier 2 Projects - GPU Acceleration (Compute Shaders)
 
 ## Quality Requirements
-- [ ] Must pass `cargo check` cleanly
-- [ ] Must pass `cargo test` suite
-- [ ] No background processes in any commands - NEVER append `&`
-- [ ] Iterating multiple mutable SoA arrays in `rayon` must chain `.par_iter_mut().zip(...)`
-- [ ] WGSL shaders must avoid 16-byte alignment crashes by using flat `array<f32>` and Rust structs must use `#[repr(C)]`, `Pod`, and `Zeroable`.
+- [ ] Code passes standard Rust checks: `cargo check` and `cargo test`.
+- [ ] No background processes in any commands - NEVER append `&`.
+- [ ] Strict use of `wide` crate for SIMD operations. Do NOT use `std::simd` (`portable_simd`).
+- [ ] Avoid Array of Structures (AoS) SIMD on individual math primitives like `Vector3d`.
+- [ ] Arithmetic methods in `Vector3d` must use standard scalar math (f32) to comply with SoA architectural pattern.
+- [ ] WGPU implementations must use flat `array<f32>` in WGSL instead of `array<vec3<f32>>` to avoid memory alignment crashes.
+- [ ] Modularity maintained for GPU and CCD features as optional add-ons to prevent scope creep.
 
 ## Technical Notes
-**Development Stack**: Rust, rayon, wide, libm, wgpu (~v0.19), WGSL
-**Special Instructions**: Ensure DOD refactoring is complete before implementing SIMD vectorization to allow SoA optimization. Risk of scope creep with GPU/CCD features; modularize as optional add-ons to not block v1.0.0.
-**Timeline Expectations**: Milestones to be met for 0.4.0, 0.6.0, 0.7.0, and 0.8.0 as per strategic portfolio plan. Target 30-60 minutes maximum per actionable development task.
+**Development Stack**: Rust, rayon, wide, libm, wgpu, WGSL
+**Special Instructions**: Front-load investment in architectural refactoring (ECS compatibility) to minimize technical debt. SOTA features (CCD, GPU acceleration) will be modularized as optional add-ons to not block 1.0.0.
+**Timeline Expectations**: Maintaining 95% on-time delivery. v0.4.0 for CCD, v0.6.0 for DOD/SIMD, v0.7.0/v1.0.0 for Determinism, post-v0.6.0 for experimental GPU features.


### PR DESCRIPTION
Creates a detailed task list mapped from the project's state-of-the-art technical specifications (including Continuous Collision Detection, Data-Oriented Design, SIMD Vectorization, Determinism, and GPU Compute Shaders).

Each task is assigned a specific agency role for resolution, issuing, and testing, as requested. The task list correctly drops the web boilerplate from the PM instructions in favor of relevant constraints (e.g., `wide` crate, `rayon`, avoiding `&` background processes).

---
*PR created automatically by Jules for task [13417740721431856630](https://jules.google.com/task/13417740721431856630) started by @DanielMarcos1*