### PR TITLE
Create Strategic Portfolio Plan Issue for SOTA Scope Expansion

### DIFF
--- a/ISSUE_SOTA_SCOPE_EXPANSION.md
+++ b/ISSUE_SOTA_SCOPE_EXPANSION.md
@@ -1,0 +1,36 @@
+# Strategic Portfolio Plan: Worm Engine SOTA Scope Expansion
+
+## Executive Summary
+**Strategic Objectives**: Evolve the Worm Engine from a functional 3D physics engine into a state-of-the-art, high-performance solution. Align technical milestones to deliver hyper-performance, deterministic simulation, and memory efficiency to meet the anticipated market shift toward highly scalable, data-oriented multiplayer experiences.
+**Portfolio Value**: Projected 35% ROI through competitive licensing and modular architecture, maintaining the benchmark of 95% on-time delivery for the core v1.0.0 roadmap milestones.
+**Market Opportunity**: Secure top-tier market share in the simulation and gaming sectors by fulfilling market demand for AAA-grade features without compromising the established release cadence.
+**Resource Strategy**: Mobilize senior systems programming talent and optimize the R&D budget for advanced physics algorithms, Data-Oriented Design (DOD) refactoring, and Rust-native optimizations.
+
+## Project Portfolio Overview
+**Tier 1 Projects** (Strategic Priority):
+- **Continuous Collision Detection (CCD)**: [Budget: 15% R&D, Timeline: v0.4.0, Expected ROI: 20% market share increase, Strategic Impact: Prevents tunneling at high velocities. Critical for fast-paced action titles and AAA adoption.]
+  - *Resource allocation and success metrics*: 2 dedicated physics engineers; success measured by 0% tunneling at 1000m/s velocities. Modular add-on to avoid blocking 1.0.0.
+- **Data-Oriented Design (DOD) & ECS Compatibility**: [Budget: 25% R&D, Timeline: v0.6.0, Expected ROI: 40% increase in integration adoption, Strategic Impact: Ensures seamless integration with modern ECS architectures (Bevy, Flecs).]
+  - *Resource allocation and success metrics*: 1 architecture lead; success measured by API integration time under 2 hours.
+- **Multithreading and SIMD Vectorization**: [Budget: 20% R&D, Timeline: v0.6.0, Expected ROI: Secures performance leadership, Strategic Impact: Maximizes CPU utilization using rayon and wide (SIMD).]
+  - *Resource allocation and success metrics*: Systems Engineering team; success measured by linear scaling up to 16 threads.
+
+**Tier 2 Projects** (Growth Initiatives):
+- **Cross-Platform Determinism**: [Budget: 10% R&D, Timeline: v0.7.0/v1.0.0, Expected ROI: 15% premium licensing increase, Market Impact: Essential for competitive multiplayer and rollback netcode.]
+  - *Dependencies and risk assessment*: Strict floating-point math control and deterministic solver execution. Requires robust CI testing.
+
+**Innovation Pipeline**:
+- **GPU Acceleration (Compute Shaders)**: [Experimental initiatives with learning objectives: Future-proofing for massive scale simulations via WGPU integration.]
+  - *Technology adoption and capability development*: Requires stabilization of the core CPU physics pipeline first. Risk of scope creep, thus kept modular.
+
+## Resource Allocation Strategy
+**Team Capacity**: Reallocating 30% of R&D capacity to specialized algorithmic optimization (SIMD/Multithreading) and DOD.
+**Skill Development**: Upskilling current engineering team in advanced DOD patterns and deterministic mathematics.
+**External Partners**: Establish strategic alliances with leading Rust game engine maintainers (e.g., Bevy, WGPU communities) for early integration testing.
+**Budget Distribution**: Front-loading investment in architectural refactoring (ECS compatibility) to minimize technical debt.
+
+## Risk Management and Contingency
+**Portfolio Risks**: Expanding project scope with SOTA features could jeopardize the core 1.0.0 delivery timeline and increase complexity.
+**Mitigation Strategies**: Implement strict agile milestones. High-risk features (CCD, GPU acceleration) will be modularized as optional add-ons rather than hard blockers for 1.0.0.
+**Contingency Planning**: Fallback to single-threaded, discrete collision detection if multithreading synchronization introduces unresolvable latency.
+**Success Metrics**: Maintain >25% portfolio ROI, achieve 95% on-time delivery of the 1.0.0 core features alongside revised SOTA features.


### PR DESCRIPTION
This submission fulfills the request to analyze the project scope and create a GitHub issue outlining what needs to be done to maintain the project's state-of-the-art status. Due to the lack of a GitHub token, the issue was created as a local markdown file named `ISSUE_SOTA_SCOPE_EXPANSION.md`. The document strictly follows the "Strategic Portfolio Plan" template and aligns with the "Studio Producer" persona, detailing Tier 1 (CCD, DOD, SIMD) and Tier 2 (Determinism, GPU) projects along with required ROI and on-time delivery metrics.

---
*PR created automatically by Jules for task [17074473855655423829](https://jules.google.com/task/17074473855655423829) started by @DanielMarcos1*