### PR TITLE
Fix SOTA implementations and build issues

### DIFF
--- a/src/geometry/vector.rs
+++ b/src/geometry/vector.rs
@@ -23,36 +23,31 @@ impl Vector3d {
         }
     }
 
-    // Internal helper to get SIMD representation (padding with 0.0)
-    #[inline(always)]
-    fn to_simd(&self) -> f32x4 {
-        f32x4::new([self.x, self.y, self.z, 0.0])
-    }
-
-    // Internal helper to create Vector3d from SIMD
-    #[inline(always)]
-    fn from_simd(simd: f32x4) -> Self {
-        let arr = simd.to_array();
-        Self {
-            x: arr[0],
-            y: arr[1],
-            z: arr[2],
-        }
-    }
 
     // A vector of 3d must have basic arithmetic calculations to represent it's location on the environment
     pub fn add(&self, other: &Vector3d) -> Vector3d {
-        Self::from_simd(self.to_simd() + other.to_simd())
+        Self {
+            x: self.x + other.x,
+            y: self.y + other.y,
+            z: self.z + other.z,
+        }
     }
 
     pub fn subtract(&self, other: &Vector3d) -> Vector3d {
-        Self::from_simd(self.to_simd() - other.to_simd())
+        Self {
+            x: self.x - other.x,
+            y: self.y - other.y,
+            z: self.z - other.z,
+        }
     }
 
     // Scalar multiplication has the purpose to control vector speed without changing its direction
     pub fn scale(&self, scalar: f32) -> Vector3d {
-        let scalar_simd = f32x4::splat(scalar);
-        Self::from_simd(self.to_simd() * scalar_simd)
+        Self {
+            x: self.x * scalar,
+            y: self.y * scalar,
+            z: self.z * scalar,
+        }
     }
 
     // This represents the length or size of the vector
@@ -72,9 +67,7 @@ impl Vector3d {
 
     // Look at where the vector is pointing at and it's relative direction compared to other vectors
     pub fn dot(&self, other: &Vector3d) -> f32 {
-        let mul = self.to_simd() * other.to_simd();
-        let arr = mul.to_array();
-        arr[0] + arr[1] + arr[2]
+        self.x * other.x + self.y * other.y + self.z * other.z
     }
 
     // This can be used to calculate many things like perpendicular directions,

--- a/src/physics/gpu.rs
+++ b/src/physics/gpu.rs
@@ -118,7 +118,7 @@ impl GpuContext {
         );
 
         // Submit the commands to the queue
-        let submission_index = self.queue.submit(Some(encoder.finish()));
+        self.queue.submit(Some(encoder.finish()));
 
         // Map the staging buffer so we can read it on CPU
         let buffer_slice = staging_buffer.slice(..);

--- a/src/physics/rigid_body.rs
+++ b/src/physics/rigid_body.rs
@@ -13,7 +13,7 @@ pub fn update(components: &mut RigidBodyComponents, index: usize, dt: f32) {
     let mass = components.masses[index];
     let force = components.forces[index];
 
-    let mut accel = force.scale(1.0 / mass);
+    let accel = force.scale(1.0 / mass);
     components.accelerations[index] = accel;
 
     let mut vel = components.velocities[index];

--- a/src/physics/world.rs
+++ b/src/physics/world.rs
@@ -10,12 +10,12 @@ pub struct World {
     pub next_entity: usize,
 
     // SoA (Struct of Arrays) layout for DOD
-    pub positions: Vec<Position>,
-    pub velocities: Vec<Velocity>,
-    pub accelerations: Vec<Acceleration>,
-    pub forces: Vec<Force>,
-    pub masses: Vec<Mass>,
-    pub shapes: Vec<Shape>,
+    pub positions: Vec<Vector3d>,
+    pub velocities: Vec<Vector3d>,
+    pub accelerations: Vec<Vector3d>,
+    pub forces: Vec<Vector3d>,
+    pub masses: Vec<f32>,
+    pub shapes: Vec<Polygon>,
     pub active_entities: Vec<bool>, // true if entity is active
 }
 
@@ -116,7 +116,7 @@ impl World {
             for i in start..end {
                 let mass = self.bodies.masses[i];
                 let gravity_force = crate::physics::constants::GRAVITY.scale(mass);
-                let mut force = self.bodies.forces[i].add(&gravity_force);
+                let force = self.bodies.forces[i].add(&gravity_force);
 
                 let accel = force.scale(1.0 / mass);
                 self.bodies.accelerations[i] = accel;


### PR DESCRIPTION
- Replaced SIMD types in `Vector3d` operations with standard scalar math to fix build issues.
- Fixed unused `mut` variable warnings in `src/physics/world.rs` and `src/physics/rigid_body.rs`.
- Fixed unused variable warning `submission_index` in `src/physics/gpu.rs`.
- Replaced missing custom type aliases (`Position`, `Velocity`, etc.) in `src/physics/world.rs` with their base types (`Vector3d`, `f32`, `Polygon`) to fix the build errors.

---
*PR created automatically by Jules for task [13340407720620693667](https://jules.google.com/task/13340407720620693667) started by @DanielMarcos1*