### PR TITLE
Add SOTA GitHub Issue Draft

### DIFF
--- a/WORM_ENGINE_SOTA_GITHUB_ISSUE.md
+++ b/WORM_ENGINE_SOTA_GITHUB_ISSUE.md
@@ -1,0 +1,41 @@
+# Elevate Worm Engine to State-of-the-Art (SOTA) Market Leadership
+
+## Labels
+enhancement, strategic, architecture, performance, physics
+
+## Body
+To elevate the Worm Engine from a functional 3D physics engine into a state-of-the-art, high-performance solution, we need to expand our scope and tackle the following strategic initiatives. This will position us to capture top-tier market share and prepare for highly scalable, data-oriented multiplayer experiences.
+
+### Tier 1 Projects (Strategic Priority)
+
+- **Continuous Collision Detection (CCD) Implementation**
+  - **Description**: Implement CCD to prevent "tunneling" at high velocities. This involves calculating time of impact (TOI) between moving bodies.
+  - **Acceptance Criteria**: 0% tunneling at up to 1000m/s; CCD pipeline integrates with existing collision detection; performance impact within acceptable bounds.
+  - **Assignment**: Continuous Collision Detection (CCD) Implementation needs to be resolved/issued/tested by the Physics Engineer.
+  - **Target Files**: `src/physics/ccd.rs`, `src/physics/mod.rs`, `src/physics/world.rs`
+
+- **Data-Oriented Design (DOD) & ECS Refactoring**
+  - **Description**: Refactor core engine structures to support Data-Oriented Design, making it compatible with modern ECS architectures like Bevy and Flecs.
+  - **Acceptance Criteria**: Memory layout optimized for cache coherency; API allows integration with a standard ECS in under 2 hours; core systems operate on flat arrays.
+  - **Assignment**: Data-Oriented Design (DOD) & ECS Refactoring needs to be resolved/issued/tested by the Architecture Lead.
+  - **Target Files**: `src/physics/rigid_body.rs`, `src/physics/world.rs`, `src/physics/components.rs`
+
+- **Multithreading and SIMD Vectorization**
+  - **Description**: Integrate `rayon` for task-based parallelism and `std::simd` for vectorizing math operations.
+  - **Acceptance Criteria**: Engine scales linearly up to 16 threads; core math operations utilize SIMD; thread synchronization does not introduce unresolvable latency.
+  - **Assignment**: Multithreading and SIMD Vectorization needs to be resolved/issued/tested by the Systems Engineer.
+  - **Target Files**: `Cargo.toml`, `src/geometry/vector.rs`, `src/physics/world.rs`
+
+### Tier 2 Projects (Growth Initiatives)
+
+- **Cross-Platform Determinism Setup**
+  - **Description**: Implement strict floating-point math control and deterministic solver execution across multiple architectures.
+  - **Acceptance Criteria**: Simulation yields identical results across CPU architectures; CI includes deterministic behavior checks; fallback mechanisms implemented.
+  - **Assignment**: Cross-Platform Determinism Setup needs to be resolved/issued/tested by the Systems Engineer.
+  - **Target Files**: `src/physics/math.rs`, `src/physics/constants.rs`
+
+- **GPU Acceleration (Compute Shaders) Integration**
+  - **Description**: Future-proof the engine by integrating WGPU for GPU-accelerated compute shaders (soft-bodies/fluids).
+  - **Acceptance Criteria**: Basic WGPU context established; prototype compute shader runs; CPU pipeline remains stable.
+  - **Assignment**: GPU Acceleration (Compute Shaders) Integration needs to be resolved/issued/tested by the Graphics Engineer.
+  - **Target Files**: `Cargo.toml`, `src/physics/gpu.rs`, `shaders/compute.wgsl`


### PR DESCRIPTION
Drafts a new markdown file containing the "Elevate Worm Engine to State-of-the-Art (SOTA) Market Leadership" GitHub issue, assigning tasks to appropriate roles.

---
*PR created automatically by Jules for task [15424126673620176933](https://jules.google.com/task/15424126673620176933) started by @DanielMarcos1*