### PR TITLE
Fix compilation errors in physics core and geometry math

### DIFF
--- a/src/geometry/vector.rs
+++ b/src/geometry/vector.rs
@@ -1,3 +1,4 @@
+use wide::f32x4;
 use bytemuck::{Pod, Zeroable};
 use crate::physics::math::DeterministicMath;
 

--- a/src/physics/gpu.rs
+++ b/src/physics/gpu.rs
@@ -118,7 +118,7 @@ impl GpuContext {
         );
 
         // Submit the commands to the queue
-        let submission_index = self.queue.submit(Some(encoder.finish()));
+        let _submission_index = self.queue.submit(Some(encoder.finish()));
 
         // Map the staging buffer so we can read it on CPU
         let buffer_slice = staging_buffer.slice(..);

--- a/src/physics/rigid_body.rs
+++ b/src/physics/rigid_body.rs
@@ -13,7 +13,7 @@ pub fn update(components: &mut RigidBodyComponents, index: usize, dt: f32) {
     let mass = components.masses[index];
     let force = components.forces[index];
 
-    let mut accel = force.scale(1.0 / mass);
+    let accel = force.scale(1.0 / mass);
     components.accelerations[index] = accel;
 
     let mut vel = components.velocities[index];

--- a/src/physics/world.rs
+++ b/src/physics/world.rs
@@ -1,4 +1,4 @@
-use crate::{geometry::polygon::Polygon, physics::components::RigidBodyComponents, physics::rigid_body};
+use crate::{geometry::polygon::Polygon, physics::components::RigidBodyComponents};
 use rayon::prelude::*;
 use wide::f32x4;
 use crate::geometry::vector::Vector3d;
@@ -10,12 +10,12 @@ pub struct World {
     pub next_entity: usize,
 
     // SoA (Struct of Arrays) layout for DOD
-    pub positions: Vec<Position>,
-    pub velocities: Vec<Velocity>,
-    pub accelerations: Vec<Acceleration>,
-    pub forces: Vec<Force>,
-    pub masses: Vec<Mass>,
-    pub shapes: Vec<Shape>,
+    pub positions: Vec<Vector3d>,
+    pub velocities: Vec<Vector3d>,
+    pub accelerations: Vec<Vector3d>,
+    pub forces: Vec<Vector3d>,
+    pub masses: Vec<f32>,
+    pub shapes: Vec<Polygon>,
     pub active_entities: Vec<bool>, // true if entity is active
 }
 
@@ -116,7 +116,7 @@ impl World {
             for i in start..end {
                 let mass = self.bodies.masses[i];
                 let gravity_force = crate::physics::constants::GRAVITY.scale(mass);
-                let mut force = self.bodies.forces[i].add(&gravity_force);
+                let force = self.bodies.forces[i].add(&gravity_force);
 
                 let accel = force.scale(1.0 / mass);
                 self.bodies.accelerations[i] = accel;


### PR DESCRIPTION
This PR implements fixes for the rust compiler errors and warnings blocking the build. It targets structural type definitions in the physics world logic and adds the missing wide SIMD dependency import for vector math. 

Changes:
- Set up domain-appropriate explicit concrete types (`Vector3d`, `f32`, `Polygon`) in the `World` struct (Data-Oriented Design ECS refactoring preparation).
- Address missing import for `wide::f32x4`.
- Resolve unused variables and `mut` warnings.

---
*PR created automatically by Jules for task [11386148386193905368](https://jules.google.com/task/11386148386193905368) started by @DanielMarcos1*