### PR TITLE
Generate GitHub Issues for SOTA Integration Tasks

### DIFF
--- a/CCD_GITHUB_ISSUE.md
+++ b/CCD_GITHUB_ISSUE.md
@@ -1,0 +1,21 @@
+# Continuous Collision Detection (CCD) Implementation
+## Labels
+enhancement, physics
+## Body
+Implement Continuous Collision Detection to prevent "tunneling" at high velocities. This involves calculating time of impact (TOI) between moving bodies.
+
+### Acceptance Criteria
+- 0% tunneling observed at velocities up to 1000m/s.
+- CCD pipeline integrates with the existing collision detection system.
+- Performance impact remains within acceptable bounds for high-speed simulations.
+
+### Files to Create/Edit
+- src/physics/ccd.rs
+- src/physics/mod.rs
+- src/physics/world.rs
+
+### Reference
+Tier 1 Projects - Continuous Collision Detection (CCD)
+
+### Assignment
+Continuous Collision Detection (CCD) Implementation needs to be resolved/issued/tested by the Physics Engineer

--- a/DETERMINISM_GITHUB_ISSUE.md
+++ b/DETERMINISM_GITHUB_ISSUE.md
@@ -1,0 +1,21 @@
+# Cross-Platform Determinism Setup
+## Labels
+determinism, ci
+## Body
+Implement strict floating-point math control and deterministic solver execution across multiple architectures.
+
+### Acceptance Criteria
+- Simulation yields identical results across different CPU architectures.
+- CI testing pipeline includes deterministic behavior checks.
+- Fallback mechanisms for non-deterministic math functions are implemented.
+
+### Files to Create/Edit
+- src/physics/math.rs
+- src/physics/constants.rs
+- Tests related to cross-platform execution.
+
+### Reference
+Tier 2 Projects - Cross-Platform Determinism
+
+### Assignment
+Cross-Platform Determinism Setup needs to be resolved/issued/tested by the Systems Engineer

--- a/DOD_GITHUB_ISSUE.md
+++ b/DOD_GITHUB_ISSUE.md
@@ -1,0 +1,21 @@
+# Data-Oriented Design (DOD) & ECS Refactoring
+## Labels
+architecture, refactoring
+## Body
+Refactor core engine structures to support Data-Oriented Design, making it compatible with modern ECS architectures like Bevy and Flecs.
+
+### Acceptance Criteria
+- Memory layout is optimized for cache coherency.
+- API allows integration with a standard ECS in under 2 hours.
+- Core systems (e.g., rigid body updates) operate on flat arrays or similar DOD structures.
+
+### Files to Create/Edit
+- src/physics/rigid_body.rs
+- src/physics/world.rs
+- src/physics/components.rs
+
+### Reference
+Tier 1 Projects - Data-Oriented Design (DOD) & ECS Compatibility
+
+### Assignment
+Data-Oriented Design (DOD) & ECS Refactoring needs to be resolved/issued/tested by the Architecture Lead

--- a/GPU_GITHUB_ISSUE.md
+++ b/GPU_GITHUB_ISSUE.md
@@ -1,0 +1,21 @@
+# GPU Acceleration (Compute Shaders) Integration
+## Labels
+gpu, wgpu
+## Body
+Future-proof the engine by integrating WGPU for GPU-accelerated compute shaders, initially targeting massive scale simulations like soft-bodies or fluids.
+
+### Acceptance Criteria
+- Basic WGPU context is established and integrated into the build.
+- A prototype compute shader runs and passes data back to the CPU physics pipeline.
+- CPU pipeline remains stable during GPU execution.
+
+### Files to Create/Edit
+- Cargo.toml
+- src/physics/gpu.rs
+- shaders/compute.wgsl
+
+### Reference
+Tier 2 Projects - GPU Acceleration (Compute Shaders)
+
+### Assignment
+GPU Acceleration (Compute Shaders) Integration needs to be resolved/issued/tested by the Graphics Engineer

--- a/SIMD_GITHUB_ISSUE.md
+++ b/SIMD_GITHUB_ISSUE.md
@@ -1,0 +1,21 @@
+# Multithreading and SIMD Vectorization
+## Labels
+performance, optimization
+## Body
+Integrate `rayon` for task-based parallelism and `std::simd` for vectorizing math operations in the physics pipeline.
+
+### Acceptance Criteria
+- Engine scales linearly up to 16 threads on supported hardware.
+- Core math operations (vector additions, dot products, cross products) utilize SIMD instructions.
+- Thread synchronization does not introduce unresolvable latency.
+
+### Files to Create/Edit
+- Cargo.toml
+- src/geometry/vector.rs
+- src/physics/world.rs
+
+### Reference
+Tier 1 Projects - Multithreading and SIMD Vectorization
+
+### Assignment
+Multithreading and SIMD Vectorization needs to be resolved/issued/tested by the Systems Engineer

--- a/ai/memory-bank/tasks/worm-engine-tasklist.md
+++ b/ai/memory-bank/tasks/worm-engine-tasklist.md
@@ -20,7 +20,7 @@
 - src/physics/world.rs
 
 **Reference**: Issue Task 1 CCD
-**Assignment**: Physics Engineer needs to resolve/issue/test this feature.
+**Assignment**: Continuous Collision Detection (CCD) needs to be resolved/issued/tested by the Physics Engineer
 
 ### [ ] Task 2: Data-Oriented Design (DOD) & ECS Refactoring (30-60 minutes)
 **Description**: Refactor core engine structures to support Data-Oriented Design, making it compatible with modern ECS architectures like Bevy and Flecs.
@@ -35,7 +35,7 @@
 - src/physics/components.rs
 
 **Reference**: Issue Task 2 DOD
-**Assignment**: Architecture Lead needs to resolve/issue/test this feature.
+**Assignment**: Data-Oriented Design (DOD) & ECS Refactoring needs to be resolved/issued/tested by the Architecture Lead
 
 ### [ ] Task 3: Multithreading Implementation
 **Description**: Integrate `rayon` for task-based parallelism. Refactor parallel iteration over large mutable SoA arrays in `World::step` to chain `.par_iter_mut().zip(...)` instead of passing tuples.
@@ -49,7 +49,7 @@
 - src/physics/world.rs
 
 **Reference**: Issue Task 3 SIMD (Part 1 - Rayon)
-**Assignment**: Systems Engineer needs to resolve/issue/test this feature.
+**Assignment**: Multithreading Implementation needs to be resolved/issued/tested by the Systems Engineer
 
 ### [ ] Task 4: SIMD Vectorization Implementation
 **Description**: Integrate `wide` for vectorizing math operations in the physics pipeline. Defer until DOD refactoring is complete to use a Structure of Arrays (SoA) approach. Avoid applying Array of Structures (AoS) SIMD to individual math primitives like `Vector3d`.
@@ -63,7 +63,7 @@
 - src/physics/world.rs
 
 **Reference**: Issue Task 3 SIMD (Part 2 - SIMD)
-**Assignment**: Systems Engineer needs to resolve/issue/test this feature.
+**Assignment**: SIMD Vectorization Implementation needs to be resolved/issued/tested by the Systems Engineer
 
 ### [ ] Task 5: Cross-Platform Determinism Setup
 **Description**: Implement strict floating-point math control and deterministic solver execution across multiple architectures using `libm`.
@@ -77,7 +77,7 @@
 - src/physics/constants.rs
 
 **Reference**: Issue Task 4 Determinism
-**Assignment**: Systems Engineer needs to resolve/issue/test this feature.
+**Assignment**: Cross-Platform Determinism Setup needs to be resolved/issued/tested by the Systems Engineer
 
 ### [ ] Task 6: GPU Acceleration (Compute Shaders) Integration
 **Description**: Integrate `wgpu` (~v0.19) for GPU-accelerated compute shaders targeting massive scale simulations. `Vector3d` sent via `bytemuck` must use `#[repr(C)]` with `Pod` and `Zeroable` derives. In WGSL, use a flat `array<f32>` (indexing by 3) instead of `array<vec3<f32>>`.
@@ -92,7 +92,7 @@
 - shaders/compute.wgsl
 
 **Reference**: Issue Task 5 GPU
-**Assignment**: Graphics Engineer needs to resolve/issue/test this feature.
+**Assignment**: GPU Acceleration (Compute Shaders) Integration needs to be resolved/issued/tested by the Graphics Engineer
 
 ## Quality Requirements
 - [ ] Must pass `cargo check` cleanly


### PR DESCRIPTION
Generated separate markdown files for each project task (CCD, DOD, SIMD, Determinism, and GPU) adhering to the GitHub issue format. Also updated the main task list to explicitly reference the task name and role assignments using the specified wording. Restored previously altered source files (which had unresolved compile errors that are out of scope for documentation changes).

---
*PR created automatically by Jules for task [13894929135143649590](https://jules.google.com/task/13894929135143649590) started by @DanielMarcos1*