### PR TITLE
Fix physics engine compiler errors and warnings

### DIFF
--- a/src/geometry/vector.rs
+++ b/src/geometry/vector.rs
@@ -1,5 +1,6 @@
-use bytemuck::{Pod, Zeroable};
 use crate::physics::math::DeterministicMath;
+use bytemuck::{Pod, Zeroable};
+use wide::f32x4;
 
 #[repr(C)]
 #[derive(Debug, Clone, Copy, Pod, Zeroable)]

--- a/src/physics/components.rs
+++ b/src/physics/components.rs
@@ -1,4 +1,4 @@
-use crate::geometry::{vector::Vector3d, polygon::Polygon};
+use crate::geometry::{polygon::Polygon, vector::Vector3d};
 
 #[derive(Debug, Default)]
 pub struct RigidBodyComponents {

--- a/src/physics/gpu.rs
+++ b/src/physics/gpu.rs
@@ -23,21 +23,21 @@ impl GpuContext {
             .ok()?;
 
         let (device, queue) = adapter
-            .request_device(
-                &wgpu::DeviceDescriptor {
-                    label: Some("Worm Engine Compute Device"),
-                    required_features: wgpu::Features::empty(),
-                    required_limits: wgpu::Limits::downlevel_defaults(),
-                    memory_hints: wgpu::MemoryHints::Performance,
-                    ..Default::default()
-                },
-            )
+            .request_device(&wgpu::DeviceDescriptor {
+                label: Some("Worm Engine Compute Device"),
+                required_features: wgpu::Features::empty(),
+                required_limits: wgpu::Limits::downlevel_defaults(),
+                memory_hints: wgpu::MemoryHints::Performance,
+                ..Default::default()
+            })
             .await
             .ok()?;
 
         let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
             label: Some("Compute Shader"),
-            source: wgpu::ShaderSource::Wgsl(Cow::Borrowed(include_str!("../../shaders/compute.wgsl"))),
+            source: wgpu::ShaderSource::Wgsl(Cow::Borrowed(include_str!(
+                "../../shaders/compute.wgsl"
+            ))),
         });
 
         let compute_pipeline = device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
@@ -118,7 +118,7 @@ impl GpuContext {
         );
 
         // Submit the commands to the queue
-        let submission_index = self.queue.submit(Some(encoder.finish()));
+        let _submission_index = self.queue.submit(Some(encoder.finish()));
 
         // Map the staging buffer so we can read it on CPU
         let buffer_slice = staging_buffer.slice(..);
@@ -126,10 +126,12 @@ impl GpuContext {
         buffer_slice.map_async(wgpu::MapMode::Read, move |v| sender.send(v).unwrap());
 
         // Wait for mapping to finish
-        self.device.poll(wgpu::PollType::Wait {
-            submission_index: None,
-            timeout: Some(Duration::from_secs(5)),
-        }).unwrap();
+        self.device
+            .poll(wgpu::PollType::Wait {
+                submission_index: None,
+                timeout: Some(Duration::from_secs(5)),
+            })
+            .unwrap();
 
         if let Ok(Ok(())) = receiver.await {
             let data = buffer_slice.get_mapped_range();

--- a/src/physics/mod.rs
+++ b/src/physics/mod.rs
@@ -1,9 +1,9 @@
 pub mod aabb_collision;
-pub mod sat_collision;
-pub mod rigid_body;
+pub mod ccd;
 pub mod components;
 pub mod constants;
-pub mod world;
-pub mod math;
-pub mod ccd;
 pub mod gpu;
+pub mod math;
+pub mod rigid_body;
+pub mod sat_collision;
+pub mod world;

--- a/src/physics/rigid_body.rs
+++ b/src/physics/rigid_body.rs
@@ -1,4 +1,7 @@
-use crate::{geometry::vector::Vector3d, physics::{constants::GRAVITY, components::RigidBodyComponents}};
+use crate::{
+    geometry::vector::Vector3d,
+    physics::{components::RigidBodyComponents, constants::GRAVITY},
+};
 
 pub fn apply_force(components: &mut RigidBodyComponents, index: usize, force: Vector3d) {
     components.forces[index] = components.forces[index].add(&force);
@@ -13,7 +16,7 @@ pub fn update(components: &mut RigidBodyComponents, index: usize, dt: f32) {
     let mass = components.masses[index];
     let force = components.forces[index];
 
-    let mut accel = force.scale(1.0 / mass);
+    let accel = force.scale(1.0 / mass);
     components.accelerations[index] = accel;
 
     let mut vel = components.velocities[index];

--- a/src/physics/world.rs
+++ b/src/physics/world.rs
@@ -1,8 +1,8 @@
-use crate::{geometry::polygon::Polygon, physics::components::RigidBodyComponents, physics::rigid_body};
-use rayon::prelude::*;
-use wide::f32x4;
 use crate::geometry::vector::Vector3d;
 use crate::physics::ccd::calculate_toi_sphere_sphere;
+use crate::{geometry::polygon::Polygon, physics::components::RigidBodyComponents};
+use rayon::prelude::*;
+use wide::f32x4;
 
 pub struct World {
     pub bodies: RigidBodyComponents,
@@ -10,12 +10,12 @@ pub struct World {
     pub next_entity: usize,
 
     // SoA (Struct of Arrays) layout for DOD
-    pub positions: Vec<Position>,
-    pub velocities: Vec<Velocity>,
-    pub accelerations: Vec<Acceleration>,
-    pub forces: Vec<Force>,
-    pub masses: Vec<Mass>,
-    pub shapes: Vec<Shape>,
+    pub positions: Vec<Vector3d>,
+    pub velocities: Vec<Vector3d>,
+    pub accelerations: Vec<Vector3d>,
+    pub forces: Vec<Vector3d>,
+    pub masses: Vec<f32>,
+    pub shapes: Vec<Polygon>,
     pub active_entities: Vec<bool>, // true if entity is active
 }
 
@@ -52,61 +52,78 @@ impl World {
         let exact_len = self.bodies.len() - remainder;
 
         // Process in chunks of 4 for SIMD vectorization
-        self.bodies.shapes[..exact_len].par_chunks_mut(chunk_size)
+        self.bodies.shapes[..exact_len]
+            .par_chunks_mut(chunk_size)
             .zip(self.bodies.masses[..exact_len].par_chunks_mut(chunk_size))
             .zip(self.bodies.velocities[..exact_len].par_chunks_mut(chunk_size))
             .zip(self.bodies.accelerations[..exact_len].par_chunks_mut(chunk_size))
             .zip(self.bodies.forces[..exact_len].par_chunks_mut(chunk_size))
-            .for_each(|((((shapes, masses), velocities), accelerations), forces)| {
+            .for_each(
+                |((((shapes, masses), velocities), accelerations), forces)| {
+                    let mass_simd = f32x4::from([masses[0], masses[1], masses[2], masses[3]]);
+                    let inv_mass = f32x4::splat(1.0) / mass_simd;
 
-                let mass_simd = f32x4::from([masses[0], masses[1], masses[2], masses[3]]);
-                let inv_mass = f32x4::splat(1.0) / mass_simd;
+                    // Load forces
+                    let mut f_x = f32x4::from([forces[0].x, forces[1].x, forces[2].x, forces[3].x]);
+                    let mut f_y = f32x4::from([forces[0].y, forces[1].y, forces[2].y, forces[3].y]);
+                    let mut f_z = f32x4::from([forces[0].z, forces[1].z, forces[2].z, forces[3].z]);
 
-                // Load forces
-                let mut f_x = f32x4::from([forces[0].x, forces[1].x, forces[2].x, forces[3].x]);
-                let mut f_y = f32x4::from([forces[0].y, forces[1].y, forces[2].y, forces[3].y]);
-                let mut f_z = f32x4::from([forces[0].z, forces[1].z, forces[2].z, forces[3].z]);
+                    // Apply gravity (F = F + mg)
+                    f_x = f_x + (grav_x * mass_simd);
+                    f_y = f_y + (grav_y * mass_simd);
+                    f_z = f_z + (grav_z * mass_simd);
 
-                // Apply gravity (F = F + mg)
-                f_x = f_x + (grav_x * mass_simd);
-                f_y = f_y + (grav_y * mass_simd);
-                f_z = f_z + (grav_z * mass_simd);
+                    // Calculate acceleration (a = F / m)
+                    let a_x = f_x * inv_mass;
+                    let a_y = f_y * inv_mass;
+                    let a_z = f_z * inv_mass;
 
-                // Calculate acceleration (a = F / m)
-                let a_x = f_x * inv_mass;
-                let a_y = f_y * inv_mass;
-                let a_z = f_z * inv_mass;
+                    // Load velocities
+                    let mut v_x = f32x4::from([
+                        velocities[0].x,
+                        velocities[1].x,
+                        velocities[2].x,
+                        velocities[3].x,
+                    ]);
+                    let mut v_y = f32x4::from([
+                        velocities[0].y,
+                        velocities[1].y,
+                        velocities[2].y,
+                        velocities[3].y,
+                    ]);
+                    let mut v_z = f32x4::from([
+                        velocities[0].z,
+                        velocities[1].z,
+                        velocities[2].z,
+                        velocities[3].z,
+                    ]);
 
-                // Load velocities
-                let mut v_x = f32x4::from([velocities[0].x, velocities[1].x, velocities[2].x, velocities[3].x]);
-                let mut v_y = f32x4::from([velocities[0].y, velocities[1].y, velocities[2].y, velocities[3].y]);
-                let mut v_z = f32x4::from([velocities[0].z, velocities[1].z, velocities[2].z, velocities[3].z]);
+                    // Update velocities (v = v + a * dt)
+                    v_x = v_x + (a_x * dt_simd);
+                    v_y = v_y + (a_y * dt_simd);
+                    v_z = v_z + (a_z * dt_simd);
 
-                // Update velocities (v = v + a * dt)
-                v_x = v_x + (a_x * dt_simd);
-                v_y = v_y + (a_y * dt_simd);
-                v_z = v_z + (a_z * dt_simd);
+                    // Store back
+                    let a_x_arr: [f32; 4] = a_x.into();
+                    let a_y_arr: [f32; 4] = a_y.into();
+                    let a_z_arr: [f32; 4] = a_z.into();
 
-                // Store back
-                let a_x_arr: [f32; 4] = a_x.into();
-                let a_y_arr: [f32; 4] = a_y.into();
-                let a_z_arr: [f32; 4] = a_z.into();
+                    let v_x_arr: [f32; 4] = v_x.into();
+                    let v_y_arr: [f32; 4] = v_y.into();
+                    let v_z_arr: [f32; 4] = v_z.into();
 
-                let v_x_arr: [f32; 4] = v_x.into();
-                let v_y_arr: [f32; 4] = v_y.into();
-                let v_z_arr: [f32; 4] = v_z.into();
+                    for i in 0..4 {
+                        accelerations[i] = Vector3d::new(a_x_arr[i], a_y_arr[i], a_z_arr[i]);
+                        velocities[i] = Vector3d::new(v_x_arr[i], v_y_arr[i], v_z_arr[i]);
+                        forces[i] = Vector3d::zero();
 
-                for i in 0..4 {
-                    accelerations[i] = Vector3d::new(a_x_arr[i], a_y_arr[i], a_z_arr[i]);
-                    velocities[i] = Vector3d::new(v_x_arr[i], v_y_arr[i], v_z_arr[i]);
-                    forces[i] = Vector3d::zero();
-
-                    // Update vertices
-                    for vertex in &mut shapes[i].vertices {
-                        *vertex = vertex.add(&velocities[i].scale(dt));
+                        // Update vertices
+                        for vertex in &mut shapes[i].vertices {
+                            *vertex = vertex.add(&velocities[i].scale(dt));
+                        }
                     }
-                }
-            });
+                },
+            );
 
         // Handle remainder sequentially
         if remainder > 0 {
@@ -116,7 +133,7 @@ impl World {
             for i in start..end {
                 let mass = self.bodies.masses[i];
                 let gravity_force = crate::physics::constants::GRAVITY.scale(mass);
-                let mut force = self.bodies.forces[i].add(&gravity_force);
+                let force = self.bodies.forces[i].add(&gravity_force);
 
                 let accel = force.scale(1.0 / mass);
                 self.bodies.accelerations[i] = accel;
@@ -140,7 +157,11 @@ impl World {
                 // To do exact sphere-sphere CCD we need a center and radius.
                 // Since bodies use Polygons, we'll approximate using the first vertex as center and a fixed radius.
                 // In a full implementation, the components would store a bounding sphere radius.
-                if self.bodies.shapes[i].vertices.is_empty() || self.bodies.shapes[j].vertices.is_empty() { continue; }
+                if self.bodies.shapes[i].vertices.is_empty()
+                    || self.bodies.shapes[j].vertices.is_empty()
+                {
+                    continue;
+                }
 
                 let p1 = self.bodies.shapes[i].vertices[0];
                 let v1 = self.bodies.velocities[i];
@@ -154,16 +175,20 @@ impl World {
                     // Stop the bodies exactly at the time of impact to prevent tunneling.
                     // This is a basic response - zero out velocities along the collision normal.
                     // A full solver would compute collision response at TOI.
-                    let collision_normal = (p1.add(&v1.scale(toi * dt))).subtract(&p2.add(&v2.scale(toi * dt))).normalize();
+                    let collision_normal = (p1.add(&v1.scale(toi * dt)))
+                        .subtract(&p2.add(&v2.scale(toi * dt)))
+                        .normalize();
 
                     let v1_proj = self.bodies.velocities[i].dot(&collision_normal);
                     let v2_proj = self.bodies.velocities[j].dot(&collision_normal);
 
                     if v1_proj < 0.0 {
-                        self.bodies.velocities[i] = self.bodies.velocities[i].subtract(&collision_normal.scale(v1_proj));
+                        self.bodies.velocities[i] =
+                            self.bodies.velocities[i].subtract(&collision_normal.scale(v1_proj));
                     }
                     if v2_proj > 0.0 {
-                        self.bodies.velocities[j] = self.bodies.velocities[j].subtract(&collision_normal.scale(v2_proj));
+                        self.bodies.velocities[j] =
+                            self.bodies.velocities[j].subtract(&collision_normal.scale(v2_proj));
                     }
                 }
             }


### PR DESCRIPTION
Fixes compilation errors, missing generic type aliases for the core ECS / SoA architecture, SIMD missing crate modules, and multiple dead code/mutable variable warnings to ensure the physics engine passes `cargo check` and `cargo test` smoothly for the rest of the implementations.

---
*PR created automatically by Jules for task [4888310222353149723](https://jules.google.com/task/4888310222353149723) started by @DanielMarcos1*