### PR TITLE
docs: Create role-assigned GitHub issue templates for project scope

### DIFF
--- a/ai/memory-bank/tasks/CCD_GITHUB_ISSUE.md
+++ b/ai/memory-bank/tasks/CCD_GITHUB_ISSUE.md
@@ -1,0 +1,24 @@
+# Continuous Collision Detection (CCD) Implementation
+
+## Labels
+enhancement, physics
+
+## Body
+### Description
+Implement Continuous Collision Detection to prevent "tunneling" at high velocities. This involves calculating time of impact (TOI) between moving bodies.
+
+### Acceptance Criteria
+- 0% tunneling observed at velocities up to 1000m/s.
+- CCD pipeline integrates with the existing collision detection system.
+- Performance impact remains within acceptable bounds for high-speed simulations.
+
+### Assigned Agency Role
+**Physics Engineer** needs to resolve/issue/test this feature.
+
+### Files to Create/Edit
+- src/physics/ccd.rs
+- src/physics/mod.rs
+- src/physics/world.rs
+
+### Reference
+Tier 1 Projects - Continuous Collision Detection (CCD)

--- a/ai/memory-bank/tasks/DETERMINISM_GITHUB_ISSUE.md
+++ b/ai/memory-bank/tasks/DETERMINISM_GITHUB_ISSUE.md
@@ -1,0 +1,24 @@
+# Cross-Platform Determinism Setup
+
+## Labels
+determinism, ci
+
+## Body
+### Description
+Implement strict floating-point math control and deterministic solver execution across multiple architectures.
+
+### Acceptance Criteria
+- Simulation yields identical results across different CPU architectures.
+- CI testing pipeline includes deterministic behavior checks.
+- Fallback mechanisms for non-deterministic math functions are implemented.
+
+### Assigned Agency Role
+**Systems Engineer** needs to resolve/issue/test this feature.
+
+### Files to Create/Edit
+- src/physics/math.rs
+- src/physics/constants.rs
+- Tests related to cross-platform execution.
+
+### Reference
+Tier 2 Projects - Cross-Platform Determinism

--- a/ai/memory-bank/tasks/DOD_GITHUB_ISSUE.md
+++ b/ai/memory-bank/tasks/DOD_GITHUB_ISSUE.md
@@ -1,0 +1,24 @@
+# Data-Oriented Design (DOD) & ECS Refactoring
+
+## Labels
+architecture, refactoring
+
+## Body
+### Description
+Refactor core engine structures to support Data-Oriented Design, making it compatible with modern ECS architectures like Bevy and Flecs.
+
+### Acceptance Criteria
+- Memory layout is optimized for cache coherency.
+- API allows integration with a standard ECS in under 2 hours.
+- Core systems (e.g., rigid body updates) operate on flat arrays or similar DOD structures.
+
+### Assigned Agency Role
+**Architecture Lead** needs to resolve/issue/test this feature.
+
+### Files to Create/Edit
+- src/physics/rigid_body.rs
+- src/physics/world.rs
+- src/physics/components.rs
+
+### Reference
+Tier 1 Projects - Data-Oriented Design (DOD) & ECS Compatibility

--- a/ai/memory-bank/tasks/GPU_GITHUB_ISSUE.md
+++ b/ai/memory-bank/tasks/GPU_GITHUB_ISSUE.md
@@ -1,0 +1,24 @@
+# GPU Acceleration (Compute Shaders) Integration
+
+## Labels
+gpu, wgpu
+
+## Body
+### Description
+Future-proof the engine by integrating WGPU for GPU-accelerated compute shaders, initially targeting massive scale simulations like soft-bodies or fluids.
+
+### Acceptance Criteria
+- Basic WGPU context is established and integrated into the build.
+- A prototype compute shader runs and passes data back to the CPU physics pipeline.
+- CPU pipeline remains stable during GPU execution.
+
+### Assigned Agency Role
+**Graphics Engineer** needs to resolve/issue/test this feature.
+
+### Files to Create/Edit
+- Cargo.toml
+- src/physics/gpu.rs
+- shaders/compute.wgsl
+
+### Reference
+Tier 2 Projects - GPU Acceleration (Compute Shaders)

--- a/ai/memory-bank/tasks/SIMD_GITHUB_ISSUE.md
+++ b/ai/memory-bank/tasks/SIMD_GITHUB_ISSUE.md
@@ -1,0 +1,24 @@
+# Multithreading and SIMD Vectorization
+
+## Labels
+performance, optimization
+
+## Body
+### Description
+Integrate `rayon` for task-based parallelism and `std::simd` for vectorizing math operations in the physics pipeline.
+
+### Acceptance Criteria
+- Engine scales linearly up to 16 threads on supported hardware.
+- Core math operations (vector additions, dot products, cross products) utilize SIMD instructions.
+- Thread synchronization does not introduce unresolvable latency.
+
+### Assigned Agency Role
+**Systems Engineer** needs to resolve/issue/test this feature.
+
+### Files to Create/Edit
+- Cargo.toml
+- src/geometry/vector.rs
+- src/physics/world.rs
+
+### Reference
+Tier 1 Projects - Multithreading and SIMD Vectorization


### PR DESCRIPTION
Created GitHub issue templates from scope files, assigning specific agency roles to each issue. The issues are stored in `ai/memory-bank/tasks/` according to instructions.

---
*PR created automatically by Jules for task [6746034799289378668](https://jules.google.com/task/6746034799289378668) started by @DanielMarcos1*