### PR TITLE
Add SOTA scope GitHub issue

### DIFF
--- a/ai/memory-bank/tasks/SOTA_SCOPE_GITHUB_ISSUE.md
+++ b/ai/memory-bank/tasks/SOTA_SCOPE_GITHUB_ISSUE.md
@@ -1,0 +1,30 @@
+---
+name: Worm Engine SOTA Integration Scope (v1.0.0 Roadmap)
+about: Establish strategic scope to elevate Worm Engine to State-of-the-Art market leadership.
+title: 'Worm Engine SOTA Integration Scope (v1.0.0 Roadmap)'
+labels: 'strategic, portfolio, sota'
+assignees: ''
+---
+
+## Description
+Evolve the Worm Engine from a functional 3D physics engine into a state-of-the-art (SOTA), high-performance solution. Align technical milestones to deliver hyper-performance, deterministic simulation, and memory efficiency to capture top-tier market share in the simulation and gaming sectors.
+
+## Acceptance Criteria
+- Achieve 25% portfolio ROI with balanced risk across strategic initiatives.
+- Maintain 95% on-time delivery benchmark for the core v1.0.0 roadmap milestones.
+- Core systems (e.g., rigid body updates) operate on flat arrays or similar DOD structures.
+
+## Assigned Agency Role
+**Studio Producer** needs to resolve/issue/test this feature.
+
+## Project Portfolio Overview
+**Tier 1 Projects (Strategic Priority)**:
+- **Continuous Collision Detection (CCD)**: [Budget: 15% R&D, Timeline: v0.4.0, Expected ROI: 20% market share increase, Strategic Impact: Prevents "tunneling" at high velocities (0% tunneling at 1000m/s). Critical for fast-paced action titles and AAA adoption.]
+- **Data-Oriented Design (DOD) & ECS Compatibility**: [Budget: 25% R&D, Timeline: v0.6.0, Expected ROI: 40% increase in integration adoption, Strategic Impact: Ensures seamless integration with modern ECS architectures (Bevy, Flecs). Lowers the barrier to entry for strategic partners.]
+- **Multithreading and SIMD Vectorization**: [Budget: 20% R&D, Timeline: v0.6.0, Expected ROI: Secures performance leadership, Strategic Impact: Maximizes CPU utilization using rayon and the wide crate. Essential to compete with Havok/Jolt.]
+
+**Tier 2 Projects (Growth Initiatives)**:
+- **Cross-Platform Determinism**: [Budget: 10% R&D, Timeline: v0.7.0/v1.0.0, Expected ROI: 15% premium licensing increase, Market Impact: Essential for competitive multiplayer and rollback netcode. Establishes premium brand positioning.]
+
+**Innovation Pipeline**:
+- **GPU Acceleration (Compute Shaders)**: [Experimental initiatives with learning objectives: Future-proofing for massive scale simulations (soft-bodies, fluids) via WGPU integration.]


### PR DESCRIPTION
Creates a new GitHub issue in the ai/memory-bank/tasks/ directory detailing the strategic scope and task breakdown to maintain the project scope and accomplish the state-of-the-art level.

---
*PR created automatically by Jules for task [13928622778596919622](https://jules.google.com/task/13928622778596919622) started by @DanielMarcos1*