### PR TITLE
DOD refactoring and compilation fix

### DIFF
--- a/src/geometry/vector.rs
+++ b/src/geometry/vector.rs
@@ -1,5 +1,6 @@
 use bytemuck::{Pod, Zeroable};
 use crate::physics::math::DeterministicMath;
+use wide::f32x4;
 
 #[repr(C)]
 #[derive(Debug, Clone, Copy, Pod, Zeroable)]

--- a/src/physics/gpu.rs
+++ b/src/physics/gpu.rs
@@ -118,7 +118,7 @@ impl GpuContext {
         );
 
         // Submit the commands to the queue
-        let submission_index = self.queue.submit(Some(encoder.finish()));
+        let _submission_index = self.queue.submit(Some(encoder.finish()));
 
         // Map the staging buffer so we can read it on CPU
         let buffer_slice = staging_buffer.slice(..);

--- a/src/physics/rigid_body.rs
+++ b/src/physics/rigid_body.rs
@@ -13,7 +13,7 @@ pub fn update(components: &mut RigidBodyComponents, index: usize, dt: f32) {
     let mass = components.masses[index];
     let force = components.forces[index];
 
-    let mut accel = force.scale(1.0 / mass);
+    let accel = force.scale(1.0 / mass);
     components.accelerations[index] = accel;
 
     let mut vel = components.velocities[index];

--- a/src/physics/world.rs
+++ b/src/physics/world.rs
@@ -1,28 +1,26 @@
-use crate::{geometry::polygon::Polygon, physics::components::RigidBodyComponents, physics::rigid_body};
+use crate::geometry::polygon::Polygon;
 use rayon::prelude::*;
 use wide::f32x4;
 use crate::geometry::vector::Vector3d;
 use crate::physics::ccd::calculate_toi_sphere_sphere;
 
 pub struct World {
-    pub bodies: RigidBodyComponents,
     pub time_step: f32,
     pub next_entity: usize,
 
     // SoA (Struct of Arrays) layout for DOD
-    pub positions: Vec<Position>,
-    pub velocities: Vec<Velocity>,
-    pub accelerations: Vec<Acceleration>,
-    pub forces: Vec<Force>,
-    pub masses: Vec<Mass>,
-    pub shapes: Vec<Shape>,
+    pub positions: Vec<Vector3d>,
+    pub velocities: Vec<Vector3d>,
+    pub accelerations: Vec<Vector3d>,
+    pub forces: Vec<Vector3d>,
+    pub masses: Vec<f32>,
+    pub shapes: Vec<Polygon>,
     pub active_entities: Vec<bool>, // true if entity is active
 }
 
 impl World {
     pub fn new(time_step: f32) -> Self {
         Self {
-            bodies: RigidBodyComponents::new(),
             time_step,
             next_entity: 0,
             positions: Vec::new(),
@@ -36,7 +34,14 @@ impl World {
     }
 
     pub fn add_body(&mut self, shape: Polygon, mass: f32) {
-        self.bodies.push(shape, mass);
+        assert!(mass > 0.0, "Mass must be greater than zero");
+        self.shapes.push(shape);
+        self.masses.push(mass);
+        self.velocities.push(Vector3d::zero());
+        self.accelerations.push(Vector3d::zero());
+        self.forces.push(Vector3d::zero());
+        self.positions.push(Vector3d::zero());
+        self.active_entities.push(true);
     }
 
     pub fn step(&mut self) {
@@ -48,15 +53,15 @@ impl World {
         let grav_z = f32x4::splat(gravity.z);
 
         let chunk_size = 4;
-        let remainder = self.bodies.len() % chunk_size;
-        let exact_len = self.bodies.len() - remainder;
+        let remainder = self.masses.len() % chunk_size;
+        let exact_len = self.masses.len() - remainder;
 
         // Process in chunks of 4 for SIMD vectorization
-        self.bodies.shapes[..exact_len].par_chunks_mut(chunk_size)
-            .zip(self.bodies.masses[..exact_len].par_chunks_mut(chunk_size))
-            .zip(self.bodies.velocities[..exact_len].par_chunks_mut(chunk_size))
-            .zip(self.bodies.accelerations[..exact_len].par_chunks_mut(chunk_size))
-            .zip(self.bodies.forces[..exact_len].par_chunks_mut(chunk_size))
+        self.shapes[..exact_len].par_chunks_mut(chunk_size)
+            .zip(self.masses[..exact_len].par_chunks_mut(chunk_size))
+            .zip(self.velocities[..exact_len].par_chunks_mut(chunk_size))
+            .zip(self.accelerations[..exact_len].par_chunks_mut(chunk_size))
+            .zip(self.forces[..exact_len].par_chunks_mut(chunk_size))
             .for_each(|((((shapes, masses), velocities), accelerations), forces)| {
 
                 let mass_simd = f32x4::from([masses[0], masses[1], masses[2], masses[3]]);
@@ -111,43 +116,43 @@ impl World {
         // Handle remainder sequentially
         if remainder > 0 {
             let start = exact_len;
-            let end = self.bodies.len();
+            let end = self.masses.len();
 
             for i in start..end {
-                let mass = self.bodies.masses[i];
+                let mass = self.masses[i];
                 let gravity_force = crate::physics::constants::GRAVITY.scale(mass);
-                let mut force = self.bodies.forces[i].add(&gravity_force);
+                let force = self.forces[i].add(&gravity_force);
 
                 let accel = force.scale(1.0 / mass);
-                self.bodies.accelerations[i] = accel;
+                self.accelerations[i] = accel;
 
-                let mut velocity = self.bodies.velocities[i];
+                let mut velocity = self.velocities[i];
                 velocity = velocity.add(&accel.scale(dt));
-                self.bodies.velocities[i] = velocity;
+                self.velocities[i] = velocity;
 
-                for vertex in &mut self.bodies.shapes[i].vertices {
+                for vertex in &mut self.shapes[i].vertices {
                     *vertex = vertex.add(&velocity.scale(dt));
                 }
 
-                self.bodies.forces[i] = Vector3d::zero();
+                self.forces[i] = Vector3d::zero();
             }
         }
 
         // CCD phase (Basic n^2 implementation for spheres for demonstration, normally would use broadphase)
-        let num_bodies = self.bodies.len();
+        let num_bodies = self.masses.len();
         for i in 0..num_bodies {
             for j in (i + 1)..num_bodies {
                 // To do exact sphere-sphere CCD we need a center and radius.
                 // Since bodies use Polygons, we'll approximate using the first vertex as center and a fixed radius.
                 // In a full implementation, the components would store a bounding sphere radius.
-                if self.bodies.shapes[i].vertices.is_empty() || self.bodies.shapes[j].vertices.is_empty() { continue; }
+                if self.shapes[i].vertices.is_empty() || self.shapes[j].vertices.is_empty() { continue; }
 
-                let p1 = self.bodies.shapes[i].vertices[0];
-                let v1 = self.bodies.velocities[i];
+                let p1 = self.shapes[i].vertices[0];
+                let v1 = self.velocities[i];
                 let r1 = 1.0; // Approximation
 
-                let p2 = self.bodies.shapes[j].vertices[0];
-                let v2 = self.bodies.velocities[j];
+                let p2 = self.shapes[j].vertices[0];
+                let v2 = self.velocities[j];
                 let r2 = 1.0; // Approximation
 
                 if let Some(toi) = calculate_toi_sphere_sphere(p1, v1, r1, p2, v2, r2, dt) {
@@ -156,14 +161,14 @@ impl World {
                     // A full solver would compute collision response at TOI.
                     let collision_normal = (p1.add(&v1.scale(toi * dt))).subtract(&p2.add(&v2.scale(toi * dt))).normalize();
 
-                    let v1_proj = self.bodies.velocities[i].dot(&collision_normal);
-                    let v2_proj = self.bodies.velocities[j].dot(&collision_normal);
+                    let v1_proj = self.velocities[i].dot(&collision_normal);
+                    let v2_proj = self.velocities[j].dot(&collision_normal);
 
                     if v1_proj < 0.0 {
-                        self.bodies.velocities[i] = self.bodies.velocities[i].subtract(&collision_normal.scale(v1_proj));
+                        self.velocities[i] = self.velocities[i].subtract(&collision_normal.scale(v1_proj));
                     }
                     if v2_proj > 0.0 {
-                        self.bodies.velocities[j] = self.bodies.velocities[j].subtract(&collision_normal.scale(v2_proj));
+                        self.velocities[j] = self.velocities[j].subtract(&collision_normal.scale(v2_proj));
                     }
                 }
             }


### PR DESCRIPTION
Refactor World struct to correctly adhere to DOD logic by removing `RigidBodyComponents` wrapper, and fixing `f32x4` and variable warnings in the codebase.

---
*PR created automatically by Jules for task [757711313495447861](https://jules.google.com/task/757711313495447861) started by @DanielMarcos1*