### PR TITLE
docs: Create SOTA Scope GitHub issue as Studio Producer

### DIFF
--- a/ai/memory-bank/tasks/SOTA_SCOPE_GITHUB_ISSUE.md
+++ b/ai/memory-bank/tasks/SOTA_SCOPE_GITHUB_ISSUE.md
@@ -1,0 +1,41 @@
+---
+name: Elevate Worm Engine to State-of-the-Art (SOTA) Level
+about: Analyze project scope and integrate SOTA features (CCD, DOD, SIMD, Determinism, GPU Acceleration).
+title: 'Strategic Initiative: Elevating Worm Engine to State-of-the-Art (SOTA) Market Leadership'
+labels: 'strategic, epic, enhancement'
+assignees: ''
+---
+
+## Description
+Evolve the Worm Engine from a functional 3D physics engine into a state-of-the-art, high-performance solution capable of capturing top-tier market share in the simulation and gaming sectors. The current physics engine landscape demands hyper-performance, memory efficiency, and deterministic simulation. By adding critical missing architectural features, we position Worm Engine perfectly for the anticipated market shift toward highly scalable, data-oriented multiplayer experiences.
+
+### Tier 1 Projects (Strategic Priority):
+- **Continuous Collision Detection (CCD)**: Prevents "tunneling" at high velocities. Critical for fast-paced action titles and AAA adoption.
+- **Data-Oriented Design (DOD) & ECS Compatibility**: Ensures seamless integration with modern Entity-Component-System architectures (e.g., Bevy, Flecs).
+- **Multithreading and SIMD Vectorization**: Maximizes CPU utilization using `rayon` and `wide` crate (not std::simd) for cross-platform SIMD vectorization to compete with industry giants.
+
+### Tier 2 Projects (Growth Initiatives):
+- **Cross-Platform Determinism**: Essential for competitive multiplayer and rollback netcode.
+- **GPU Acceleration (Compute Shaders)**: Future-proofing for massive scale simulations via WGPU integration (~v0.19).
+
+## Acceptance Criteria
+- Core 1.0.0 roadmap milestones maintain our 95% on-time delivery benchmark.
+- Maintain an overall 25%+ portfolio ROI with balanced risk management.
+- SOTA features are implemented as modular add-ons to prevent blocking the v1.0.0 core delivery timeline.
+- Engine performance reaches a top 3 benchmark ranking among open-source Rust physics engines.
+
+## Technical Notes
+- **SIMD**: Use `wide` crate for cross-platform SIMD vectorization, strictly avoiding `std::simd`.
+- **GPU**: For WGSL shaders, avoid `wgpu` 16-byte alignment issues by using flat `array<f32>` instead of `vec3<f32>` to match standard Rust `bytemuck` arrays.
+- **Multithreading**: Iterating multiple mutable Struct of Arrays (SoA) vectors in `rayon` must chain the iterators using `.par_iter_mut().zip(...)` or `.par_chunks_mut(chunk_size).zip(...)`, avoiding tuple chaining that causes compile issues.
+- **Architecture**: Apply SIMD vectorization over SoA chunks, explicitly avoiding Array of Structures (AoS) SIMD on individual math primitives like `Vector3d`.
+
+## Assigned Agency Role
+**Studio Producer** needs to oversee the portfolio management and ensure business value. Specific technical implementation assigned to Architecture Lead, Physics Engineer, Systems Engineer, and Graphics Engineer.
+
+## Files to Create/Edit
+- Multiple source files in `src/physics/` and `src/geometry/` (see individual task issues).
+- `Cargo.toml`
+
+## Reference
+Strategic Portfolio Plan: Worm Engine SOTA Integration


### PR DESCRIPTION
Created a strategic planning GitHub issue to elevate Worm Engine to a State-of-the-Art (SOTA) level, enforcing the required executive metrics and SOTA features (CCD, DOD, SIMD, Determinism, GPU).

---
*PR created automatically by Jules for task [6461903049285590940](https://jules.google.com/task/6461903049285590940) started by @DanielMarcos1*