### PR TITLE
docs: Format and move assigned task issues to memory bank

### DIFF
--- a/ai/memory-bank/tasks/CCD_GITHUB_ISSUE.md
+++ b/ai/memory-bank/tasks/CCD_GITHUB_ISSUE.md
@@ -1,0 +1,24 @@
+# Continuous Collision Detection (CCD) Implementation
+
+## Labels
+enhancement, physics
+
+## Body
+**Description**:
+Implement Continuous Collision Detection to prevent "tunneling" at high velocities. This involves calculating time of impact (TOI) between moving bodies.
+
+**Acceptance Criteria**:
+- 0% tunneling observed at velocities up to 1000m/s.
+- CCD pipeline integrates with the existing collision detection system.
+- Performance impact remains within acceptable bounds for high-speed simulations.
+
+**Files to Create/Edit**:
+- src/physics/ccd.rs
+- src/physics/mod.rs
+- src/physics/world.rs
+
+**Assigned Agency Role**:
+**Physics Engineer** needs to resolve/issue/test this feature.
+
+**Reference**:
+Tier 1 Projects - Continuous Collision Detection (CCD)

--- a/ai/memory-bank/tasks/DETERMINISM_GITHUB_ISSUE.md
+++ b/ai/memory-bank/tasks/DETERMINISM_GITHUB_ISSUE.md
@@ -1,0 +1,24 @@
+# Cross-Platform Determinism Setup
+
+## Labels
+determinism, ci
+
+## Body
+**Description**:
+Implement strict floating-point math control and deterministic solver execution across multiple architectures using `libm`.
+
+**Acceptance Criteria**:
+- Simulation yields identical results across different CPU architectures.
+- CI testing pipeline includes deterministic behavior checks.
+- Fallback mechanisms for non-deterministic math functions are implemented.
+
+**Files to Create/Edit**:
+- src/physics/math.rs
+- src/physics/constants.rs
+- Tests related to cross-platform execution.
+
+**Assigned Agency Role**:
+**Systems Engineer** needs to resolve/issue/test this feature.
+
+**Reference**:
+Tier 2 Projects - Cross-Platform Determinism

--- a/ai/memory-bank/tasks/DOD_GITHUB_ISSUE.md
+++ b/ai/memory-bank/tasks/DOD_GITHUB_ISSUE.md
@@ -1,0 +1,24 @@
+# Data-Oriented Design (DOD) & ECS Refactoring
+
+## Labels
+architecture, refactoring
+
+## Body
+**Description**:
+Refactor core engine structures to support Data-Oriented Design, making it compatible with modern ECS architectures like Bevy and Flecs.
+
+**Acceptance Criteria**:
+- Memory layout is optimized for cache coherency.
+- API allows integration with a standard ECS in under 2 hours.
+- Core systems (e.g., rigid body updates) operate on flat arrays or similar DOD structures.
+
+**Files to Create/Edit**:
+- src/physics/rigid_body.rs
+- src/physics/world.rs
+- src/physics/components.rs
+
+**Assigned Agency Role**:
+**Architecture Lead** needs to resolve/issue/test this feature.
+
+**Reference**:
+Tier 1 Projects - Data-Oriented Design (DOD) & ECS Compatibility

--- a/ai/memory-bank/tasks/GPU_GITHUB_ISSUE.md
+++ b/ai/memory-bank/tasks/GPU_GITHUB_ISSUE.md
@@ -1,0 +1,24 @@
+# GPU Acceleration (Compute Shaders) Integration
+
+## Labels
+gpu, wgpu
+
+## Body
+**Description**:
+Integrate `wgpu` (~v0.19) for GPU-accelerated compute shaders targeting massive scale simulations. `Vector3d` sent via `bytemuck` must use `#[repr(C)]` with `Pod` and `Zeroable` derives. In WGSL, use a flat `array<f32>` (indexing by 3) instead of `array<vec3<f32>>`.
+
+**Acceptance Criteria**:
+- Basic WGPU context is established and integrated into the build.
+- A prototype compute shader runs and passes data back to the CPU physics pipeline.
+- CPU pipeline remains stable during GPU execution with no 16-byte memory alignment crashes.
+
+**Files to Create/Edit**:
+- Cargo.toml
+- src/physics/gpu.rs
+- shaders/compute.wgsl
+
+**Assigned Agency Role**:
+**Graphics Engineer** needs to resolve/issue/test this feature.
+
+**Reference**:
+Tier 2 Projects - GPU Acceleration (Compute Shaders)

--- a/ai/memory-bank/tasks/MULTITHREADING_GITHUB_ISSUE.md
+++ b/ai/memory-bank/tasks/MULTITHREADING_GITHUB_ISSUE.md
@@ -1,0 +1,23 @@
+# Multithreading Implementation
+
+## Labels
+performance, optimization
+
+## Body
+**Description**:
+Integrate `rayon` for task-based parallelism. Refactor parallel iteration over large mutable SoA arrays in `World::step` to chain `.par_iter_mut().zip(...)` instead of passing tuples.
+
+**Acceptance Criteria**:
+- Engine scales linearly up to 16 threads on supported hardware.
+- Thread synchronization does not introduce unresolvable latency.
+- SIMD vectorization utilizes a Structure of Arrays (SoA) approach rather than AoS on individual math primitives.
+
+**Files to Create/Edit**:
+- Cargo.toml
+- src/physics/world.rs
+
+**Assigned Agency Role**:
+**Systems Engineer** needs to resolve/issue/test this feature.
+
+**Reference**:
+Issue Task 3 SIMD (Part 1 - Rayon)

--- a/ai/memory-bank/tasks/SIMD_GITHUB_ISSUE.md
+++ b/ai/memory-bank/tasks/SIMD_GITHUB_ISSUE.md
@@ -1,0 +1,23 @@
+# SIMD Vectorization Implementation
+
+## Labels
+performance, optimization
+
+## Body
+**Description**:
+Integrate `wide` for vectorizing math operations in the physics pipeline. Defer until DOD refactoring is complete to use a Structure of Arrays (SoA) approach. Avoid applying Array of Structures (AoS) SIMD to individual math primitives like `Vector3d`.
+
+**Acceptance Criteria**:
+- Core math operations (vector additions, dot products, cross products) utilize SIMD instructions.
+- SIMD implementation leverages SoA approach exclusively without overhead on individual primitives.
+
+**Files to Create/Edit**:
+- Cargo.toml
+- src/geometry/vector.rs
+- src/physics/world.rs
+
+**Assigned Agency Role**:
+**Systems Engineer** needs to resolve/issue/test this feature.
+
+**Reference**:
+Issue Task 3 SIMD (Part 2 - SIMD)


### PR DESCRIPTION
Reformatted previously drafted GitHub issues for CCD, DOD, SIMD, Determinism, and GPU integration to match the explicit markdown structure (# Title, ## Labels, ## Body) and explicitly added assigned agency roles. Saved to ai/memory-bank/tasks/ and removed redundant root files.

---
*PR created automatically by Jules for task [17103313606404929707](https://jules.google.com/task/17103313606404929707) started by @DanielMarcos1*