### PR TITLE
Add Strategic SOTA Scope GitHub Issue

### DIFF
--- a/ai/memory-bank/tasks/WORM_ENGINE_SOTA_SCOPE_GITHUB_ISSUE.md
+++ b/ai/memory-bank/tasks/WORM_ENGINE_SOTA_SCOPE_GITHUB_ISSUE.md
@@ -1,0 +1,60 @@
+# Elevate Worm Engine to State-of-the-Art (SOTA) Market Leadership
+
+## Labels
+strategic, enhancement, architecture, performance, physics
+
+## Body
+### 🎯 Executive Summary
+**Strategic Objectives**: Evolve the Worm Engine from a functional 3D physics engine into a state-of-the-art (SOTA), high-performance solution. Align our technical milestones to deliver hyper-performance, deterministic simulation, and memory efficiency, positioning us for the anticipated market shift toward highly scalable, data-oriented multiplayer experiences.
+**Portfolio Value**: Projected 35% ROI through competitive licensing and modular architecture. Maintains our 95% on-time delivery benchmark for the core v1.0.0 roadmap milestones.
+**Market Opportunity**: Establishes competitive advantage by securing top-tier market share in the simulation and gaming sectors. Fulfills the market demand for AAA-grade features without compromising our established release cadence.
+**Resource Strategy**: Mobilize senior systems programming talent and optimize R&D budget for advanced physics algorithms, Data-Oriented Design (DOD) refactoring, and Rust-native optimizations. Reallocating 30% of R&D capacity to specialized algorithmic optimization.
+
+### 📊 Project Portfolio Overview & Technical Scope
+
+#### Tier 1 Projects (Strategic Priority):
+
+**1. Data-Oriented Design (DOD) & ECS Compatibility**
+- *Budget & Timeline*: 25% R&D, Timeline: v0.6.0
+- *Strategic Impact*: Ensures seamless integration with modern ECS architectures (Bevy, Flecs). Lowers the barrier to entry for strategic partners.
+- *Expected ROI*: 40% increase in integration adoption.
+- *Technical Constraints*:
+  - Memory layout must be optimized for cache coherency using a Data-Oriented Design (DOD) with a Structure of Arrays (SoA) layout.
+  - The `World` struct must directly own core memory arrays (`Vec<Vector3d>` for positions, velocities, etc., `Vec<f32>` for masses, `Vec<Polygon>` for shapes) without intermediate component structs.
+- *Assigned Agency Role*: **Architecture Lead** needs to resolve/issue/test this feature.
+
+**2. Multithreading and SIMD Vectorization**
+- *Budget & Timeline*: 20% R&D, Timeline: v0.6.0
+- *Strategic Impact*: Maximizes CPU utilization. Essential to compete with industry giants (Havok, Jolt).
+- *Expected ROI*: Secures performance leadership. Success measured by linear scaling up to 16 threads.
+- *Technical Constraints*:
+  - SIMD vectorization must be applied over SoA chunks using the `wide` crate.
+  - Explicitly avoid Array of Structures (AoS) SIMD on individual math primitives like `Vector3d`, and avoid using `std::simd`.
+  - When iterating multiple mutable SoA vectors in `rayon`, chain the iterators using `.par_iter_mut().zip(...)` for standard iteration, or `.par_chunks_mut(chunk_size).zip(...)` when processing SIMD chunks.
+- *Assigned Agency Role*: **Systems Engineer** needs to resolve/issue/test this feature.
+
+**3. Continuous Collision Detection (CCD)**
+- *Budget & Timeline*: 15% R&D, Timeline: v0.4.0
+- *Strategic Impact*: Prevents "tunneling" at high velocities. Critical for fast-paced action titles and AAA adoption.
+- *Expected ROI*: 20% market share increase. Success measured by 0% tunneling at 1000m/s velocities.
+- *Assigned Agency Role*: **Physics Engineer** needs to resolve/issue/test this feature.
+
+#### Tier 2 Projects (Growth Initiatives):
+
+**1. Cross-Platform Determinism**
+- *Budget & Timeline*: 10% R&D, Timeline: v0.7.0/v1.0.0
+- *Market Impact*: Essential for competitive multiplayer and rollback netcode. Establishes premium brand positioning.
+- *Dependencies*: Strict floating-point math control and deterministic solver execution. Robust CI testing across multiple architectures required.
+- *Assigned Agency Role*: **Systems Engineer** needs to resolve/issue/test this feature.
+
+**2. GPU Acceleration (Compute Shaders)**
+- *Experimental Initiative*: Future-proofing for massive scale simulations (soft-bodies, fluids) via WGPU integration.
+- *Technical Constraints*:
+  - For WGSL shaders, avoid 16-byte alignment crashes by using flat `array<f32>` instead of `vec3<f32>` to match standard Rust `bytemuck` arrays.
+- *Assigned Agency Role*: **Graphics Engineer** needs to resolve/issue/test this feature.
+
+### 🛡️ Risk Management and Contingency
+**Portfolio Risks**: Expanding scope could jeopardize the 1.0.0 delivery timeline. Complexity of deterministic cross-platform math might extend R&D phase and increase costs.
+**Mitigation Strategies**: Implement strict agile milestones. If CCD or GPU acceleration threatens the core roadmap, they will be modularized as optional add-ons rather than blocking 1.0.0.
+**Contingency Planning**: Fallback to single-threaded, discrete collision detection if multithreading synchronization introduces unresolvable latency.
+**Success Metrics**: Maintain >25% portfolio ROI, achieve 95% on-time delivery of the revised features, and reach a top 3 benchmark performance among open-source Rust physics engines.


### PR DESCRIPTION
Adds a new strategic GitHub issue for the Worm Engine project, adopting the "Studio Producer" persona to outline the Tier 1 and Tier 2 objectives necessary to elevate the engine to SOTA status (CCD, DOD, SIMD, Determinism, GPU Acceleration). The issue follows the required template structure and integrates specific, previously-established technical constraints.

---
*PR created automatically by Jules for task [6093307556077432606](https://jules.google.com/task/6093307556077432606) started by @DanielMarcos1*